### PR TITLE
Load CodeGenerator by name

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -155,8 +155,12 @@ THE POSSIBILITY OF SUCH DAMAGE.
 	<target name="jar-nocompile" depends="jar-check" unless="jar.uptodate">
 		<mkdir dir="${target-folder}" />
 		<antcall target="compile" />
-		<jar jarfile="${javacc}" basedir="classes" compress="true" />
-		<jar jarfile="${javacc-path}" basedir="classes" compress="true" />
+		<jar jarfile="${javacc}" basedir="classes" compress="true">
+			<metainf dir="${java-src}/META-INF"></metainf>
+		</jar>
+		<jar jarfile="${javacc-path}" basedir="classes" compress="true">
+			<metainf dir="${java-src}/META-INF"></metainf>
+		</jar>
 	</target>
 
 	<target name="dist" depends="jar, javadoc" description="build a distribution">

--- a/codegenerator/csharp/build.xml
+++ b/codegenerator/csharp/build.xml
@@ -41,7 +41,9 @@ Copyright (c) 2017, Microsoft
 	<target name="jar-nocompile">
 		<mkdir dir="lib" />
 		<antcall target="compile" />
-		<jar jarfile="csharp-codegenerator.jar" basedir="classes" compress="true" />
+		<jar jarfile="csharp-codegenerator.jar" basedir="classes" compress="true">
+			<metainf dir="${java-src}/META-INF"></metainf>
+		</jar>
 	</target>
 
 </project>

--- a/codegenerator/csharp/src/java/META-INF/services/org.javacc.parser.CodeGenerator
+++ b/codegenerator/csharp/src/java/META-INF/services/org.javacc.parser.CodeGenerator
@@ -1,0 +1,1 @@
+org.javacc.csharp.CodeGenerator

--- a/codegenerator/csharp/src/java/org/javacc/csharp/CodeGenerator.java
+++ b/codegenerator/csharp/src/java/org/javacc/csharp/CodeGenerator.java
@@ -9,6 +9,15 @@ import org.javacc.parser.*;
 public class CodeGenerator implements org.javacc.parser.CodeGenerator
 {
   /**
+   * The name of the C# code generator.
+   */
+  @Override
+  public String getName() 
+  {
+    return "C#";
+  }
+
+  /**
    * Generate any other support files you need.
    */
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,8 @@
-<?xml version="1.0"?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<groupId>net.java.dev.javacc</groupId>
 	<artifactId>javacc</artifactId>
 	<packaging>jar</packaging>
@@ -116,6 +118,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>javacc-maven-plugin</artifactId>
+				<version>2.6</version>
 				<executions>
 					<execution>
 						<id>jcc</id>
@@ -158,9 +161,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.7.0</version>
 				<configuration>
-					<source>5</source>
-					<target>5</target>
+					<source>6</source>
+					<target>6</target>
 					<excludes>
 						<exclude>**/*Test.java</exclude>
 					</excludes>
@@ -169,6 +173,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.20.1</version>
 				<configuration>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					<forkMode>once</forkMode>

--- a/src/main/java/META-INF/services/org.javacc.parser.CodeGenerator
+++ b/src/main/java/META-INF/services/org.javacc.parser.CodeGenerator
@@ -1,0 +1,1 @@
+org.javacc.parser.JavaCodeGenerator

--- a/src/main/java/org/javacc/parser/CodeGenerator.java
+++ b/src/main/java/org/javacc/parser/CodeGenerator.java
@@ -3,6 +3,11 @@ package org.javacc.parser;
 public interface CodeGenerator
 {
   /**
+   * Get the name of the code generator.
+   */
+  String getName();
+  
+  /**
    * Generate any other support files you need.
    */
   boolean generateHelpers(CodeGeneratorSettings settings);

--- a/src/main/java/org/javacc/parser/JavaCCGlobals.java
+++ b/src/main/java/org/javacc/parser/JavaCCGlobals.java
@@ -34,6 +34,7 @@ import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 
 import org.javacc.Version;
 
@@ -354,15 +355,24 @@ public class JavaCCGlobals {
   static public CodeGenerator getCodeGenerator() {
     if (codeGenerator != null) return codeGenerator;
 
-    String className = Options.getCodeGenerator();
-    if (className == null) return null;
+    String name = Options.getCodeGenerator();
+    if (name == null) return null;
+    
+    ServiceLoader<CodeGenerator> serviceLoader = ServiceLoader.load(CodeGenerator.class);
+    for (CodeGenerator generator : serviceLoader) {
+      if(generator.getName().equalsIgnoreCase(name)) {
+        codeGenerator = generator;
+        return codeGenerator;
+      }
+    }
+    
     try
     {
-      codeGenerator = ((Class<CodeGenerator>)Class.forName(className)).newInstance();
+      codeGenerator = ((Class<CodeGenerator>)Class.forName(name)).newInstance();
     }
     catch(Exception e)
     {
-      JavaCCErrors.semantic_error("Could not load the CodeGenerator class: \"" + className + "\"");
+      JavaCCErrors.semantic_error("Could not load the CodeGenerator class: \"" + name + "\"");
     }
 
     return codeGenerator;

--- a/src/main/java/org/javacc/parser/JavaCodeGenerator.java
+++ b/src/main/java/org/javacc/parser/JavaCodeGenerator.java
@@ -5,6 +5,15 @@ import org.javacc.parser.JavaFiles.JavaResourceTemplateLocations;
 public class JavaCodeGenerator implements CodeGenerator
 {
   /**
+   * The name of the Java code generator.
+   */
+  @Override
+  public String getName() 
+  {
+    return "Java";
+  }
+
+  /**
    * Generate any other support files you need.
    */
   @Override


### PR DESCRIPTION
Using Java ServiceLoader to load a pluggable CodeGenerator by name instead by classname. The CodeGenerator can be loaded still by classname, as fallback mechanism. The preferred way would be:

`CODE_GENERATOR = "c#";`