### PR TITLE
Add support for Java7 language features

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -576,10 +576,40 @@ THE POSSIBILITY OF SUCH DAMAGE.
 
 		<javac srcdir="${test-tmp}/Obfuscator" includeantruntime='false'/>
 
-		<!-- TODO, test cases for SimpleExamples -->
-
 		<echo />
 
+		<!-- Test cases for SimpleExamples -->
+		<mkdir dir="${test-tmp}/SimpleExamples" />
+		
+		<java failonerror="true" fork="true" classname="javacc" classpath="${javacc}">
+			<arg line="-OUTPUT_DIRECTORY=${test-tmp}/SimpleExamples examples/SimpleExamples/Simple1.jj" />
+		</java>
+		
+		<java failonerror="true" fork="true" classname="javacc" classpath="${javacc}">
+			<arg line="-OUTPUT_DIRECTORY=${test-tmp}/SimpleExamples examples/SimpleExamples/Simple2.jj" />
+		</java>
+		
+		<java failonerror="true" fork="true" classname="javacc" classpath="${javacc}">
+			<arg line="-OUTPUT_DIRECTORY=${test-tmp}/SimpleExamples examples/SimpleExamples/Simple3.jj" />
+		</java>
+		
+		<java failonerror="true" fork="true" classname="javacc" classpath="${javacc}">
+			<arg line="-OUTPUT_DIRECTORY=${test-tmp}/SimpleExamples examples/SimpleExamples/NL_Xlator.jj" />
+		</java>
+		
+		<java failonerror="true" fork="true" classname="javacc" classpath="${javacc}">
+			<arg line="-OUTPUT_DIRECTORY=${test-tmp}/SimpleExamples examples/SimpleExamples/IdList.jj" />
+		</java>
+		<echo />
+		
+		<!-- Test cases for Java 7 syntax features -->
+		<mkdir dir="${test-tmp}/java7features" />
+		
+		<java failonerror="true" fork="true" classname="javacc" classpath="${javacc}">
+			<arg line="-OUTPUT_DIRECTORY=${test-tmp}/java7features test/java7features/Parser.jj" />
+		</java>
+		
+		<echo />
 		<copy todir="${test-tmp}/Transformer">
 			<fileset dir="examples/Transformer">
 				<include name="*.java" />

--- a/src/main/javacc/JavaCC.jj
+++ b/src/main/javacc/JavaCC.jj
@@ -2819,16 +2819,25 @@ void SynchronizedStatement():
   "synchronized" "(" Expression(null) ")" Block(null)
 }
 
-void TryStatement():
-/*
- * Semantic check required here to make sure that at least one
- * finally/catch is present.
- */
+void ResourceDeclaration():
 {}
 {
-  "try" Block(null)
-  ( "catch" "(" FormalParameter() ")" Block(null) )*
-  [ "finally" Block(null) ]
+  Type() VariableDeclaratorId() "=" Expression(null)
+}
+
+void TryStatement():
+{ boolean empty = true; }
+{
+  "try" ["("  ResourceDeclaration()
+         (LOOKAHEAD(2) ";" ResourceDeclaration())* (";")? ")" { empty = false; }
+         ] Block(null)
+  ( "catch" "(" FormalParameter() ")" Block(null) { empty = false; } )*
+  [ "finally" Block(null) { empty = false; } ]
+
+  {
+  if (empty)
+      throw new ParseException("At least one catch or finally block expected.");
+  }
 }
 
 /* We use productions to match >>>, >> and > so that we can keep the

--- a/src/main/javacc/JavaCC.jj
+++ b/src/main/javacc/JavaCC.jj
@@ -2065,7 +2065,7 @@ void TypeArguments(List tokens):
 }
 {
    "<"   { first = getToken(0); }
-   TypeArgument() ( "," TypeArgument() [ "..." ] )*
+   [ TypeArgument() ( "," TypeArgument() [ "..." ] )* ]
    ">"
    {
      last = getToken(0);

--- a/src/main/javacc/JavaCC.jj
+++ b/src/main/javacc/JavaCC.jj
@@ -447,13 +447,16 @@ TOKEN :
         <DECIMAL_LITERAL> (["l","L"])?
       | <HEX_LITERAL> (["l","L"])?
       | <OCTAL_LITERAL> (["l","L"])?
+      | <BINARY_LITERAL> (["l","L"])?
   >
 |
-  < #DECIMAL_LITERAL: ["1"-"9"] (["0"-"9"])* >
+  < #DECIMAL_LITERAL: ["1"-"9"] (("_")* ["0"-"9"])* >
 |
-  < #HEX_LITERAL: "0" ["x","X"] (["0"-"9","a"-"f","A"-"F"])+ >
+  < #HEX_LITERAL: "0" ["x","X"] ["0"-"9","a"-"f","A"-"F"] (("_")* ["0"-"9","a"-"f","A"-"F"])* >
 |
-  < #OCTAL_LITERAL: "0" (["0"-"7"])* >
+  < #OCTAL_LITERAL: "0" (("_")* ["0"-"7"])* >
+|
+  < #BINARY_LITERAL: "0" ["b","B"] ["0", "1"] (("_")* ["0","1"])* >
 |
   < FLOATING_POINT_LITERAL:
         <DECIMAL_FLOATING_POINT_LITERAL>
@@ -461,20 +464,21 @@ TOKEN :
   >
 |
   < #DECIMAL_FLOATING_POINT_LITERAL:
-        (["0"-"9"])+ "." (["0"-"9"])* (<DECIMAL_EXPONENT>)? (["f","F","d","D"])?
-      | "." (["0"-"9"])+ (<DECIMAL_EXPONENT>)? (["f","F","d","D"])?
-      | (["0"-"9"])+ <DECIMAL_EXPONENT> (["f","F","d","D"])?
-      | (["0"-"9"])+ (<DECIMAL_EXPONENT>)? ["f","F","d","D"]
+        ["0"-"9"] (("_")* ["0"-"9"])* "." (["0"-"9"](("_")*["0"-"9"])*)? (<DECIMAL_EXPONENT>)? (["f","F","d","D"])?
+      | "." ["0"-"9"](("_")*["0"-"9"])* (<DECIMAL_EXPONENT>)? (["f","F","d","D"])?
+      | ["0"-"9"](("_")*["0"-"9"])* <DECIMAL_EXPONENT> (["f","F","d","D"])?
+      | ["0"-"9"](("_")*["0"-"9"])* (<DECIMAL_EXPONENT>)? ["f","F","d","D"]
   >
 |
-  < #DECIMAL_EXPONENT: ["e","E"] (["+","-"])? (["0"-"9"])+ >
+  < #DECIMAL_EXPONENT: ["e","E"] (["+","-"])? ["0"-"9"] (("_")*["0"-"9"])* >
 |
   < #HEXADECIMAL_FLOATING_POINT_LITERAL:
-        "0" ["x", "X"] (["0"-"9","a"-"f","A"-"F"])+ (".")? <HEXADECIMAL_EXPONENT> (["f","F","d","D"])?
-      | "0" ["x", "X"] (["0"-"9","a"-"f","A"-"F"])* "." (["0"-"9","a"-"f","A"-"F"])+ <HEXADECIMAL_EXPONENT> (["f","F","d","D"])?
+        "0" ["x", "X"] ["0"-"9","a"-"f","A"-"F"] (("_")* ["0"-"9","a"-"f","A"-"F"])* (".")? <HEXADECIMAL_EXPONENT> (["f","F","d","D"])?
+      | "0" ["x", "X"] (["0"-"9","a"-"f","A"-"F"](("_")* ["0"-"9","a"-"f","A"-"F"])* )? "." 
+           ["0"-"9","a"-"f","A"-"F"] (("_")*["0"-"9","a"-"f","A"-"F"])* <HEXADECIMAL_EXPONENT> (["f","F","d","D"])?
   >
 |
-  < #HEXADECIMAL_EXPONENT: ["p","P"] (["+","-"])? (["0"-"9"])+ >
+  < #HEXADECIMAL_EXPONENT: ["p","P"] (["+","-"])? ["0"-"9"](("_")*["0"-"9"])* >
 |
   < CHARACTER_LITERAL:
       "'"
@@ -2825,13 +2829,26 @@ void ResourceDeclaration():
   Type() VariableDeclaratorId() "=" Expression(null)
 }
 
+void CatchParameter():
+{ Token t; }
+{
+  Modifiers() Type()
+  [ ( t = "&" | t = "*") { if (!isAllowed(t)) throw new ParseException(t.image + " is invalid in this context"); }
+  	| "..."
+  ]
+  //Multiple exception catching in Java 7+
+  ("|" Type())*
+  
+  VariableDeclaratorId()
+}
+
 void TryStatement():
 { boolean empty = true; }
 {
   "try" ["("  ResourceDeclaration()
          (LOOKAHEAD(2) ";" ResourceDeclaration())* (";")? ")" { empty = false; }
          ] Block(null)
-  ( "catch" "(" FormalParameter() ")" Block(null) { empty = false; } )*
+  ( "catch" "(" CatchParameter() ")" Block(null) { empty = false; } )*
   [ "finally" Block(null) { empty = false; } ]
 
   {

--- a/test/java7features/Parser.jj
+++ b/test/java7features/Parser.jj
@@ -1,0 +1,112 @@
+/* Copyright (c) 2006, Sun Microsystems, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Sun Microsystems, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+options {
+  LOOKAHEAD = 1;
+  CHOICE_AMBIGUITY_CHECK = 2;
+  OTHER_AMBIGUITY_CHECK = 1;
+  STATIC = true;
+  DEBUG_PARSER = false;
+  DEBUG_LOOKAHEAD = false;
+  DEBUG_TOKEN_MANAGER = false;
+  ERROR_REPORTING = true;
+  JAVA_UNICODE_ESCAPE = false;
+  UNICODE_INPUT = false;
+  IGNORE_CASE = false;
+  USER_TOKEN_MANAGER = false;
+  USER_CHAR_STREAM = false;
+  BUILD_PARSER = true;
+  BUILD_TOKEN_MANAGER = true;
+  SANITY_CHECK = true;
+  FORCE_LA_CHECK = false;
+}
+
+PARSER_BEGIN(Parser)
+
+/** Simple brace matcher. */
+public class Parser {
+
+  /** Main entry point. */
+  public static void main(String args[]) throws ParseException {
+    Parser parser = new Parser(System.in);
+    parser.Input();
+  }
+
+}
+
+PARSER_END(Parser)
+
+/** Root production. */
+void Input() :
+{}
+{
+  
+  "A"  {
+     //Here we test for Java 7 language features
+     
+     //Try-with resources
+     try (Foo a = new Foo()) {
+       System.out.println("hello");
+     } catch(Exception d) {
+       System.out.println("world");
+     }
+     
+     //Multiple exception catching
+     try (Foo a = new Foo(); Bar b = new Bar()) {
+       System.out.println("hello");
+     } catch(FirstException | SecondException ex) {
+       System.out.println("world"); 
+     }
+     
+     //Underscores in numeric literals
+     int     one_million = 1_000__000;
+     int     cafe_babe   = 0xCAFE_BABE;
+     int     zero        = 0____0;
+     double  avogadro    = 6_0.22e2_2;
+     double  hundred     = 1_0_0d;
+             hundred     = 1_0_0.;
+             hundred     = 100.;
+     double  pi          = 3.141_592_65;
+     double  half        = .5_0;
+     double  h           = 0x4__3p4_4;
+     
+     //Binary literals
+     int     binary      = 0b1001_1001;
+     
+     //Type Inference for Generic Instance Creation
+     Map<String, String> m = new HashMap<>();
+     
+     //String in switch
+     String s = "foo";
+     switch(s) {
+        case "bar":
+            System.out.println("never");
+     }
+  } <EOF>
+}


### PR DESCRIPTION
Java 7 was released in 2011, however its syntax features are still unsupported in JavaCC.

The proposed change introduces the support of all the syntax features introduced in Java 7 (see [here ](https://stackoverflow.com/questions/213958/new-features-in-java-7) for reference):

* Try-with resources.
* Multiple exception catching.
* Underscores in numeric literals.
* Binary literals.
* Type Inference for Generic Instance Creation (change in `JavaCC.jj` was cherry-picked from #75).

Test is also added (in `test/java7features` and `build.xml`), as well as one TODO from `build.xml` was implemented to include `SimpleExamples` into test process.
