### PR TITLE
Allow empty type parameters in Java code of grammar files.

### DIFF
--- a/src/main/javacc/JavaCC.jj
+++ b/src/main/javacc/JavaCC.jj
@@ -2065,7 +2065,7 @@ void TypeArguments(List tokens):
 }
 {
    "<"   { first = getToken(0); }
-   TypeArgument() ( "," TypeArgument() [ "..." ] )*
+   [ TypeArgument() ( "," TypeArgument() [ "..." ] )* ]
    ">"
    {
      last = getToken(0);


### PR DESCRIPTION
This allows one to use the diamond when constructing a generic class: new ArrayList<>()

This feature of the Java compiler is documented at https://docs.oracle.com/javase/7/docs/technotes/guides/language/type-inference-generic-instance-creation.html