### PR TITLE
LookaheadSuccess creation performance improved

### DIFF
--- a/src/main/java/org/javacc/parser/ParseGen.java
+++ b/src/main/java/org/javacc/parser/ParseGen.java
@@ -625,9 +625,13 @@ public class ParseGen extends CodeGenerator implements JavaCCParserConstants {
 			genCodeLine("");
 			if (jj2index != 0) {
 				genCodeLine("  @SuppressWarnings(\"serial\")");
-				genCodeLine("  static private final class LookaheadSuccess extends "+(Options.isLegacyExceptionHandling() ? "java.lang.Error" : "java.lang.RuntimeException")+" { }");
-				genCodeLine("  " + staticOpt()
-						+ "final private LookaheadSuccess jj_ls = new LookaheadSuccess();");
+				genCodeLine("  static private final class LookaheadSuccess extends "+(Options.isLegacyExceptionHandling() ? "java.lang.Error" : "java.lang.RuntimeException")+" {");
+				genCodeLine("    @Override");
+				genCodeLine("    public Throwable fillInStackTrace() {");
+				genCodeLine("      return this;");
+				genCodeLine("    }");
+				genCodeLine("  }");
+				genCodeLine("  static private final LookaheadSuccess jj_ls = new LookaheadSuccess();");
 				genCodeLine("  " + staticOpt() + "private " + Options.getBooleanType()
 						+ " jj_scan_token(int kind) {");
 				genCodeLine("	 if (jj_scanpos == jj_lastpos) {");


### PR DESCRIPTION
Don't generate stacktrace for LookaheadSuccess. Always keep an instance in a static variable regardless of staticOpt parameter
Fixes #98 