### PR TITLE
Remove eclipse config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 .classpath
 .project
 .checkstyle
-.settings
 .idea
 *.iml
 target
@@ -16,6 +15,7 @@ build-eclipse
 
 bin/
 classes/
+.settings/
 src/main/generated-sources/
 test.tmp/
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .classpath
 .project
 .checkstyle
+.settings
 .idea
 *.iml
 target

--- a/build.xml
+++ b/build.xml
@@ -155,8 +155,16 @@ THE POSSIBILITY OF SUCH DAMAGE.
 	<target name="jar-nocompile" depends="jar-check" unless="jar.uptodate">
 		<mkdir dir="${target-folder}" />
 		<antcall target="compile" />
-		<jar jarfile="${javacc}" basedir="classes" compress="true" />
-		<jar jarfile="${javacc-path}" basedir="classes" compress="true" />
+		<jar jarfile="${javacc}" basedir="classes" compress="true">
+			<manifest>
+				<attribute name="Main-Class" value="${javacc-bootstrap-class}"/>
+			</manifest>
+		</jar>
+		<jar jarfile="${javacc-path}" basedir="classes" compress="true">
+			<manifest>
+				<attribute name="Main-Class" value="${javacc-bootstrap-class}"/>
+			</manifest>
+		</jar>
 	</target>
 
 	<target name="dist" depends="jar, javadoc" description="build a distribution">


### PR DESCRIPTION
Repo should not contain IDE-specific files. 
.gitignore has a typo - .settings is a directory not a file.