### PR TITLE
Fixing some spelling errors

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -89,7 +89,7 @@ THE POSSIBILITY OF SUCH DAMAGE.
 			<arg value="JavaCC.jj" />
 		</java>
 
-		<!-- This class is overrriden -->
+		<!-- This class is overriden -->
 		<delete file="${parser-generated-src}/Token.java" />
 
 		<!-- Generate the JJTree Parser Definition (from the tree definition) -->

--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -501,7 +501,7 @@ void handleUnexpectedToken()
  * Parameters:
  * - Token* last - the last token successfully parsed.
  * - Token* unexpected - the token at which the error occurs.
- * - string production - the name of the production in which this error occurrs.
+ * - string production - the name of the production in which this error occurs.
  */
 void handleParseError()
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1503,7 +1503,7 @@ Since JavaCC 4.0 there are constructors that take an encoding as an argument.
 
 ---
 
-This question is dependant on the application. A lot of simple applications only require a token manager. However, many people try to do too much with the lexical analyzer, for example they try to write an expression parser using only the lexical analyzer.
+This question is dependent on the application. A lot of simple applications only require a token manager. However, many people try to do too much with the lexical analyzer, for example they try to write an expression parser using only the lexical analyzer.
 
 <br>
 

--- a/docs/grammars/CParser.jj
+++ b/docs/grammars/CParser.jj
@@ -1,6 +1,6 @@
 /*
 
-  C grammar defintion for use with JavaCC
+  C grammar definition for use with JavaCC
   Contributed by Doug South (dsouth@squirrel.com.au) 21/3/97
 
   This parser assumes that the C source file has been preprocessed : all

--- a/docs/grammars/ChemNumber.jj
+++ b/docs/grammars/ChemNumber.jj
@@ -153,7 +153,7 @@ void allBaseNumbers() :
 |   < NON > {currentNumber = 9;}
 }
 
-/** Deal with fragments refering to the positioning of the base numbers (denoting their magnitude) */
+/** Deal with fragments referring to the positioning of the base numbers (denoting their magnitude) */
 void tensNoUnits() :
 {}
 {

--- a/docs/grammars/Cobol.jj
+++ b/docs/grammars/Cobol.jj
@@ -4,7 +4,7 @@
  * <li> Ralf Lämmel & Chris Verhoef : VS COBOL II grammar Version 1.0.3
  * <li> Fujitsu Cobol compiler reference
  * <li> Compaq-HP Non-stop Cobol reference
- * </od>
+ * </ol>
  * <p>This grammar is released under the GNU Library Public License (LGPL).
  * <p><address>Bernard Pinon, august 2002</address>
  * <p><address>Thierry Blind, september 2009</address>
@@ -37,7 +37,7 @@
  *   <li> corrected picture values and enhanced linkage section
  *   <li> corrected relational operators, arithmetic expressions and conditions
  *   <li> corrected perform, evaluate and call clauses
- *   <li> corrected cobol word, litteral, identifier, comment declarations
+ *   <li> corrected cobol word, literal, identifier, comment declarations
  *   <li> created Iterables*() variants for some clauses
  *   <li> added function support from cobol 2000
  *   <li> added LOOKAHEAD() instructions, with reorderings, to remove parser ambiguities

--- a/docs/grammars/EcmaScript.jjt
+++ b/docs/grammars/EcmaScript.jjt
@@ -198,7 +198,7 @@ SPECIAL_TOKEN :
 | 
 	< #NBSP: "\u00A0" > /* No-break space */
 | 
-	< #USP: /* Other Unicode space seperator */
+	< #USP: /* Other Unicode space separator */
 		["\u2000"] 
 		| ["\u2001"] 
 		| ["\u2002"] 
@@ -2256,7 +2256,7 @@ TOKEN:
 
 
 	/*
-	 * Grammar for parsing JScript .NET contructs: ( import System; var contents :
+	 * Grammar for parsing JScript .NET constructs: ( import System; var contents :
 	 * String = reader.ReadToEnd(); ) Refer: src/hostenv_jsc.js
 	 */
 

--- a/docs/grammars/FormsPlSql.jj
+++ b/docs/grammars/FormsPlSql.jj
@@ -45,7 +45,7 @@ class FormsPlSql {
             System.out.println(args[0]) ;
         }
         p.CompilationUnit() ;
-        System.out.println("Parse Successfull") ;
+        System.out.println("Parse Successful") ;
 
     } // main ends here
 } // class FormsPlSql ends here
@@ -697,7 +697,7 @@ void QueryStatement():
     ";"
 }
 
-// PLSQL Expression and it's childs
+// PLSQL Expression and it's children
 
 void PlSqlExpression():
 {}

--- a/docs/grammars/GdmoTranslator.jj
+++ b/docs/grammars/GdmoTranslator.jj
@@ -4,7 +4,7 @@
 // to build an AST which could be used for translation to UML.
 //
 // The GRAMMAR has been tested against a number of standard Managed Object
-// models but has one or two kown quirks. The main one is that at present
+// models but has one or two known quirks. The main one is that at present
 // only the double quote terminator for BEHAVIOUR and other description texts
 // is supported. It's not hard to change this but I just have not done it.
 //
@@ -56,7 +56,7 @@ public final void go() {
 	try // The Parser classes can throw a parse exception
 	{
 		// All JAVACC specifications have the same level of hierarchy
-		// therfore any of them may be used as a target production. Here
+		// therefore any of them may be used as a target production. Here
 		// we try to ecvaluate the production DocumentSpecification()
 		Node root = DocumentSpecification();
 
@@ -75,7 +75,7 @@ public final void go() {
 		// return null;
 	}
 	catch (Exception e) {
-		// Parse Error so tell the world abbout it
+		// Parse Error so tell the world about it
 		System.out.println("Ooops.");
 		System.out.println(e.getMessage());
 		e.printStackTrace();
@@ -598,7 +598,7 @@ void RegisteredAs () : { }
 	{ "REGISTERED" "AS" "{" ObjectIdentifier() "}" }
 //
 // I think that there is a fundamental problem with the use of OBJECT IDENTIFIERS in
-// GDMO. I've just copied the useage through from X.700 but there is an issue surrounding
+// GDMO. I've just copied the usage through from X.700 but there is an issue surrounding
 // whether OID NAMES are global or not. Since many of the standards reference them without
 // their associated ASN.1 module name there is an implied assumption that the names are
 // global. Sadly, however, there are some duplicates so clearly they are not!

--- a/docs/grammars/PlSql.jj
+++ b/docs/grammars/PlSql.jj
@@ -848,7 +848,7 @@ void QueryStatement():
     ";"
 }
 
-// PLSQL Expression and it's childs
+// PLSQL Expression and it's children
 
 void PlSqlExpression():
 {}

--- a/docs/tutorials/lexer-tips.md
+++ b/docs/tutorials/lexer-tips.md
@@ -13,7 +13,7 @@ This section presents a few tips for writing good lexical specifications.
   * [Avoid string literals for the same token](#tip2)
   * [Order string literals by length](#tip3)
 - [**Lexical States**](#lexical-states)
-  * [Minimise use of lexical states](#tip4)
+  * [Minimize use of lexical states](#tip4)
   * [Use SKIP as much as possible](#tip5)
   * [Avoid using SKIP with lexical actions and state changes](#tip6)
   * [Avoid using MORE if possible](#tip7)
@@ -84,7 +84,7 @@ This will help optimizing the bit vectors needed for string literals.
 
 ## <a name="lexical-states"></a>Lexical States
 
-### <a name="tip4"></a>Minimise use of lexical states
+### <a name="tip4"></a>Minimize use of lexical states
 
 Try to minimize the use of lexical states.
 

--- a/docs/tutorials/lookahead.md
+++ b/docs/tutorials/lookahead.md
@@ -382,7 +382,7 @@ if (next 2 tokens are <ID> and "(" ) {
 
 #### <a name="example9"></a>Example 9
 
-Similarily, [Example 5](#example5) can be modified as shown below:
+Similarly, [Example 5](#example5) can be modified as shown below:
 
 ```java
 void identifier_list() :

--- a/examples/GUIParsing/TokenMgrVersion/CalcGUI.java
+++ b/examples/GUIParsing/TokenMgrVersion/CalcGUI.java
@@ -80,7 +80,7 @@ public class CalcGUI extends Frame implements CalcInputParserConstants {
   static boolean firstDigit = true;
 
   /**
-   * Indicates an error has occured
+   * Indicates an error has occuered
    */
   static boolean error = false;
 

--- a/examples/GUIParsing/TokenMgrVersion/CalcInput.jj
+++ b/examples/GUIParsing/TokenMgrVersion/CalcInput.jj
@@ -56,7 +56,7 @@ TOKEN_MGR_DECLS:
    static double result = 0.0;
 
    /**
-    * Flag to indiate the very first operand so that the correct result
+    * Flag to indicate the very first operand so that the correct result
     * is displayed in this case.
     */
    static boolean firstOperand = true;

--- a/examples/GUIParsing/TokenMgrVersion/MyLexer.java
+++ b/examples/GUIParsing/TokenMgrVersion/MyLexer.java
@@ -36,7 +36,7 @@ class MyLexer extends CalcInputParserTokenManager {
 
    /**
     * We redefined the lexical error reporting function so that it beeps
-    * and displays a message thru the GUI.
+    * and displays a message through the GUI.
     */
    protected void LexicalError() {
      CalcGUI.Error("ERROR (click 0)");

--- a/examples/Lookahead/README
+++ b/examples/Lookahead/README
@@ -505,7 +505,7 @@ use a single token of LOOKAHEAD:
 	  produce an error message
 	}
 
-Similarily, Example5.jj can be modified as shown below (file
+Similarly, Example5.jj can be modified as shown below (file
 Example9.jj):
 
 	void identifier_list() :
@@ -608,9 +608,9 @@ Similarly, InterfaceDeclaration can start with any number of
 What if the next tokens in the input stream are a very large number of
 "abstract"s (say 100 of them) followed by "interface"?  It is clear
 that a fixed amount of LOOKAHEAD (such as LOOKAHEAD(100) for example)
-will not suffice.  One can argue that this is such a wierd situation
+will not suffice.  One can argue that this is such a weird situation
 that it does not warrant any reasonable error message and that it is
-okay to make the wrong choice in some pathalogical situations.  But
+okay to make the wrong choice in some pathological situations.  But
 suppose one wanted to be precise about this.
 
 The solution here is to set the LOOKAHEAD to infinity - that is set no
@@ -725,7 +725,7 @@ Let us go back to Example1.jj:
 Let us suppose that there is a good reason for writing a grammar this
 way (maybe the way actions are embedded).  As noted earlier, this
 grammar recognizes two string "abc" and "abcc".  The problem here is
-that the default LL(1) algorithm will choose the [ "c" ] everytime
+that the default LL(1) algorithm will choose the [ "c" ] every time
 it sees a "c" and therefore "abc" will never be matched.  We need to
 specify that this choice must be made only when the next token is a
 "c", and the token following that is not a "c".  This is a negative

--- a/examples/MailProcessing/sampleMailFile
+++ b/examples/MailProcessing/sampleMailFile
@@ -34,7 +34,7 @@ Note:   If you are seeing it in rmail,
 Note:    it means the file has no messages in it.
 
 1, filed,,
-Summary-line: 11-Jan       sreeni@cs.albany.edu  #A note on using RE's matching the emty string
+Summary-line: 11-Jan       sreeni@cs.albany.edu  #A note on using RE's matching the empty string
 Return-Path: <sreeni@cs.albany.edu>
 Received: from Eng.Sun.COM by schizophrenia.Eng.Sun.COM (SMI-8.6/SMI-SVR4)
 	id HAA21134; Sat, 11 Jan 1997 07:47:28 -0800
@@ -57,7 +57,7 @@ From: Sreenivasa Rao Viswanadha <sreeni@cs.albany.edu>
 Date: Sat, 11 Jan 1997 10:43:58 -0500 (EST)
 Message-Id: <199701111543.KAA09608@bhaskara.cs.albany.edu>
 To: jack-interest@asap.Eng.Sun.COM
-Subject: A note on using RE's matching the emty string
+Subject: A note on using RE's matching the empty string
 Cc: sreeni@cs.albany.edu
 X-Sun-Charset: US-ASCII
 Content-Type: text
@@ -70,7 +70,7 @@ Return-Path: <sreeni@cs.albany.edu>
 From: Sreenivasa Rao Viswanadha <sreeni@cs.albany.edu>
 Date: Sat, 11 Jan 1997 10:43:58 -0500 (EST)
 To: jack-interest@asap.Eng.Sun.COM
-Subject: A note on using RE's matching the emty string
+Subject: A note on using RE's matching the empty string
 Cc: sreeni@cs.albany.edu
 X-Sun-Charset: US-ASCII
 Content-Type: text
@@ -94,7 +94,7 @@ then if there a lexical error, say a char is given that cannot be the first one
 of any token, then, the lexer decides to use the empty string "" and match it
 as STRING_LITERAL without actually giving the lexical error. And since this is
 the empty string, no character will be consumed and you will start getting the
-same STRING_LITERAL token (with "" as the image) infinte number of times. In
+same STRING_LITERAL token (with "" as the image) infinite number of times. In
 fact, if this was the only lexical rule, then if you give a input that starts
 with any char other than the ", you will get into an infinite loop.
 

--- a/examples/Obfuscator/Obfuscator.java
+++ b/examples/Obfuscator/Obfuscator.java
@@ -59,7 +59,7 @@ public class Obfuscator extends Globals {
   }
 
   // The iterator.  This uses the above datastructures to walk the input
-  // directory tree.  Everytime it finds a Java file or when it cannot find
+  // directory tree.  Every time it finds a Java file or when it cannot find
   // any more Java file, it returns to the caller.
   static void nextJavaFile() {
     while (true) {

--- a/grammars/CParser.jj
+++ b/grammars/CParser.jj
@@ -1,6 +1,6 @@
 /*
 
-  C grammar defintion for use with JavaCC
+  C grammar definition for use with JavaCC
   Contributed by Doug South (dsouth@squirrel.com.au) 21/3/97
 
   This parser assumes that the C source file has been preprocessed : all

--- a/grammars/ChemNumber.jj
+++ b/grammars/ChemNumber.jj
@@ -153,7 +153,7 @@ void allBaseNumbers() :
 |   < NON > {currentNumber = 9;}
 }
 
-/** Deal with fragments refering to the positioning of the base numbers (denoting their magnitude) */
+/** Deal with fragments referring to the positioning of the base numbers (denoting their magnitude) */
 void tensNoUnits() :
 {}
 {

--- a/grammars/Cobol.jj
+++ b/grammars/Cobol.jj
@@ -4,7 +4,7 @@
  * <li> Ralf Lämmel & Chris Verhoef : VS COBOL II grammar Version 1.0.3
  * <li> Fujitsu Cobol compiler reference
  * <li> Compaq-HP Non-stop Cobol reference
- * </od>
+ * </ol>
  * <p>This grammar is released under the GNU Library Public License (LGPL).
  * <p><address>Bernard Pinon, august 2002</address>
  * <p><address>Thierry Blind, september 2009</address>
@@ -37,7 +37,7 @@
  *   <li> corrected picture values and enhanced linkage section
  *   <li> corrected relational operators, arithmetic expressions and conditions
  *   <li> corrected perform, evaluate and call clauses
- *   <li> corrected cobol word, litteral, identifier, comment declarations
+ *   <li> corrected cobol word, literal, identifier, comment declarations
  *   <li> created Iterables*() variants for some clauses
  *   <li> added function support from cobol 2000
  *   <li> added LOOKAHEAD() instructions, with reorderings, to remove parser ambiguities

--- a/grammars/EcmaScript.jjt
+++ b/grammars/EcmaScript.jjt
@@ -198,7 +198,7 @@ SPECIAL_TOKEN :
 | 
 	< #NBSP: "\u00A0" > /* No-break space */
 | 
-	< #USP: /* Other Unicode space seperator */
+	< #USP: /* Other Unicode space separator */
 		["\u2000"] 
 		| ["\u2001"] 
 		| ["\u2002"] 
@@ -2256,7 +2256,7 @@ TOKEN:
 
 
 	/*
-	 * Grammar for parsing JScript .NET contructs: ( import System; var contents :
+	 * Grammar for parsing JScript .NET constructs: ( import System; var contents :
 	 * String = reader.ReadToEnd(); ) Refer: src/hostenv_jsc.js
 	 */
 

--- a/grammars/FormsPlSql.jj
+++ b/grammars/FormsPlSql.jj
@@ -45,7 +45,7 @@ class FormsPlSql {
             System.out.println(args[0]) ;
         }
         p.CompilationUnit() ;
-        System.out.println("Parse Successfull") ;
+        System.out.println("Parse Successful") ;
 
     } // main ends here
 } // class FormsPlSql ends here
@@ -697,7 +697,7 @@ void QueryStatement():
     ";"
 }
 
-// PLSQL Expression and it's childs
+// PLSQL Expression and it's children
 
 void PlSqlExpression():
 {}

--- a/grammars/GdmoTranslator.jj
+++ b/grammars/GdmoTranslator.jj
@@ -4,7 +4,7 @@
 // to build an AST which could be used for translation to UML.
 //
 // The GRAMMAR has been tested against a number of standard Managed Object
-// models but has one or two kown quirks. The main one is that at present
+// models but has one or two known quirks. The main one is that at present
 // only the double quote terminator for BEHAVIOUR and other description texts
 // is supported. It's not hard to change this but I just have not done it.
 //
@@ -56,7 +56,7 @@ public final void go() {
 	try // The Parser classes can throw a parse exception
 	{
 		// All JAVACC specifications have the same level of hierarchy
-		// therfore any of them may be used as a target production. Here
+		// therefore any of them may be used as a target production. Here
 		// we try to ecvaluate the production DocumentSpecification()
 		Node root = DocumentSpecification();
 
@@ -75,7 +75,7 @@ public final void go() {
 		// return null;
 	}
 	catch (Exception e) {
-		// Parse Error so tell the world abbout it
+		// Parse Error so tell the world about it
 		System.out.println("Ooops.");
 		System.out.println(e.getMessage());
 		e.printStackTrace();
@@ -598,7 +598,7 @@ void RegisteredAs () : { }
 	{ "REGISTERED" "AS" "{" ObjectIdentifier() "}" }
 //
 // I think that there is a fundamental problem with the use of OBJECT IDENTIFIERS in
-// GDMO. I've just copied the useage through from X.700 but there is an issue surrounding
+// GDMO. I've just copied the usage through from X.700 but there is an issue surrounding
 // whether OID NAMES are global or not. Since many of the standards reference them without
 // their associated ASN.1 module name there is an implied assumption that the names are
 // global. Sadly, however, there are some duplicates so clearly they are not!

--- a/grammars/PlSql.jj
+++ b/grammars/PlSql.jj
@@ -848,7 +848,7 @@ void QueryStatement():
     ";"
 }
 
-// PLSQL Expression and it's childs
+// PLSQL Expression and it's children
 
 void PlSqlExpression():
 {}

--- a/src/main/java/org/javacc/jjtree/ASTGrammar.java
+++ b/src/main/java/org/javacc/jjtree/ASTGrammar.java
@@ -49,7 +49,7 @@ public class ASTGrammar extends JJTreeNode {
       new CPPCodeGenerator().visit(this, io);
       CPPNodeFiles.generateTreeClasses();
     } else {
-    	// Catch all to ensure we don't accidently do nothing
+    	// Catch all to ensure we don't accidentally do nothing
     	throw new RuntimeException("Language type not supported for JJTree : " + JJTreeOptions.getOutputLanguage());
     }
   }

--- a/src/main/java/org/javacc/jjtree/JJTreeIOException.java
+++ b/src/main/java/org/javacc/jjtree/JJTreeIOException.java
@@ -28,7 +28,7 @@
 package org.javacc.jjtree;
 
 /**
- * Thrown when ther is a problem reading or writing to the file system.
+ * Thrown when there is a problem reading or writing to the file system.
  */
 class JJTreeIOException extends java.io.IOException {
 

--- a/src/main/java/org/javacc/jjtree/Token.java
+++ b/src/main/java/org/javacc/jjtree/Token.java
@@ -70,7 +70,7 @@ public class Token {
   }
 
   /**
-   * No-argument contructor
+   * No-argument constructor
    */
   public Token() {}
 

--- a/src/main/java/org/javacc/parser/CharacterRange.java
+++ b/src/main/java/org/javacc/parser/CharacterRange.java
@@ -54,7 +54,7 @@ public class CharacterRange {
   {
      if (l > r)
         JavaCCErrors.semantic_error(this, "Invalid range : \"" + (int)l + "\" - \""
-              + (int)r + "\". First character shoud be less than or equal to the second one in a range.");
+              + (int)r + "\". First character should be less than or equal to the second one in a range.");
 
      setLeft(l);
      setRight(r);

--- a/src/main/java/org/javacc/parser/LexGen.java
+++ b/src/main/java/org/javacc/parser/LexGen.java
@@ -599,7 +599,7 @@ public class LexGen extends CodeGenerator implements JavaCCParserConstants
         gen = codeGenClazz.newInstance();
       } catch(Exception ee) {
         JavaCCErrors.semantic_error(
-            "Cound not load the token manager code generator class: " +
+            "Could not load the token manager code generator class: " +
             codeGeneratorClass + "\nError: " + ee.getMessage());
         return;
       }

--- a/src/main/java/org/javacc/parser/NfaState.java
+++ b/src/main/java/org/javacc/parser/NfaState.java
@@ -661,7 +661,7 @@ public class NfaState
       if (epsilonMoves.size() > 0)
       {
          for (i = 0; i < epsilonMoves.size(); i++)
-            // Since we are doing a closure, just epsilon moves are unncessary
+            // Since we are doing a closure, just epsilon moves are unnecessary
             if (((NfaState)epsilonMoves.get(i)).HasTransitions())
                usefulEpsilonMoves++;
             else
@@ -765,7 +765,7 @@ public class NfaState
       }
 
 
-      // For ranges, iterate thru the table to see if the current char
+      // For ranges, iterate through the table to see if the current char
       // is in some range
       if (rangeMoves != null && rangeMoves[0] != 0)
          for (i = 0; i < rangeMoves.length; i += 2)

--- a/src/main/java/org/javacc/parser/ParserCodeGenerator.java
+++ b/src/main/java/org/javacc/parser/ParserCodeGenerator.java
@@ -2,7 +2,7 @@ package org.javacc.parser;
 
 public interface ParserCodeGenerator {
   /**
-   * Genrate the code for the parser. Note that the code generator just
+   * Generate the code for the parser. Note that the code generator just
    * produces a buffer.
    */
   void generateCode(CodeGenerator codeGenerator, ParserData tokenizerData);

--- a/src/main/java/org/javacc/parser/Semanticize.java
+++ b/src/main/java/org/javacc/parser/Semanticize.java
@@ -233,9 +233,9 @@ public class Semanticize extends JavaCCGlobals {
                 count++;
               }
               if (count == 1) {
-                JavaCCErrors.warning(sl, "String with IGNORE_CASE is partially superceded by string at" + pos + ".");
+                JavaCCErrors.warning(sl, "String with IGNORE_CASE is partially superseded by string at" + pos + ".");
               } else {
-                JavaCCErrors.warning(sl, "String with IGNORE_CASE is partially superceded by strings at" + pos + ".");
+                JavaCCErrors.warning(sl, "String with IGNORE_CASE is partially superseded by strings at" + pos + ".");
               }
               // This entry is legitimate.  So insert it.
               if (sl.ordinal == 0) {
@@ -466,7 +466,7 @@ public class Semanticize extends JavaCCGlobals {
 
   public static RegularExpression other;
 
-  // Checks to see if the "str" is superceded by another equal (except case) string
+  // Checks to see if the "str" is superseded by another equal (except case) string
   // in table.
   public static boolean hasIgnoreCase(Hashtable<String, RegularExpression> table, String str) {
     RegularExpression rexp;

--- a/src/main/java/org/javacc/parser/Token.java
+++ b/src/main/java/org/javacc/parser/Token.java
@@ -70,7 +70,7 @@ public class Token {
   }
 
   /**
-   * No-argument contructor
+   * No-argument constructor
    */
   public Token() {}
 

--- a/src/main/java/org/javacc/parser/TokenManagerCodeGenerator.java
+++ b/src/main/java/org/javacc/parser/TokenManagerCodeGenerator.java
@@ -2,7 +2,7 @@ package org.javacc.parser;
 
 public interface TokenManagerCodeGenerator {
   /**
-   * Genrate the code for the token manager. Note that the code generator just
+   * Generate the code for the token manager. Note that the code generator just
    * produces a buffer.
    */
   void generateCode(TokenizerData tokenizerData);

--- a/src/main/java/package.html
+++ b/src/main/java/package.html
@@ -8,6 +8,6 @@ content="text/html; charset=us-ascii" />
 <title>Default package</title>
 </head>
 <body bgcolor="white">
-<p>A package independant layer for ease of use in scripts.</p>
+<p>A package independent layer for ease of use in scripts.</p>
 </body>
 </html>

--- a/src/main/javacc/ConditionParser.jj
+++ b/src/main/javacc/ConditionParser.jj
@@ -23,7 +23,7 @@
  */
 
 /*
- * This file contains a simple parser to evaulate simple boolean conditions,
+ * This file contains a simple parser to evalulate simple boolean conditions,
  * such as
  *   !value1 || value2
  */

--- a/src/main/resources/templates/CharStream.template
+++ b/src/main/resources/templates/CharStream.template
@@ -73,7 +73,7 @@ interface CharStream {
    * Backs up the input stream by amount steps. Lexer calls this method if it
    * had already read some characters, but could not use them to match a
    * (longer) token. So, they will be used again as the prefix of the next
-   * token and it is the implemetation's responsibility to do this right.
+   * token and it is the implementation's responsibility to do this right.
    */
   void backup(int amount);
 

--- a/src/main/resources/templates/ParseException.template
+++ b/src/main/resources/templates/ParseException.template
@@ -61,7 +61,7 @@ public class ParseException extends Exception {
   /**
    * This is the last token that has been consumed successfully.  If
    * this object has been created due to a parse error, the token
-   * followng this token will (therefore) be the first error token.
+   * following this token will (therefore) be the first error token.
    */
   public Token currentToken;
 

--- a/src/main/resources/templates/TableDrivenTokenManager.template
+++ b/src/main/resources/templates/TableDrivenTokenManager.template
@@ -248,7 +248,7 @@ private ${STATIC?static :}final int jjMoveNfa(int startState, int curPos) {
       // We found a match. So remember the kind and position of the match.
       jjmatchedKind = kind;
       jjmatchedPos = curPos;
-      // Reset the kind to max value so we can contine looking for a longer
+      // Reset the kind to max value so we can continue looking for a longer
       // match.
       kind = Integer.MAX_VALUE;
     }
@@ -279,7 +279,7 @@ private ${STATIC?static :}final int jjMoveNfa(int startState, int curPos) {
   } while (cnt > 0);
 
   assert(false) :
-      "Interal error. Please submit a bug at: http://javacc.java.net.";
+      "Internal error. Please submit a bug at: http://javacc.java.net.";
   return curPos;
 }
 
@@ -399,7 +399,7 @@ public ${STATIC?static :} Token getNextToken() {
                        input_stream.getBeginColumn());
 #fi
 
-    // Set matched kind to a MAX VALUE to implement largest, first occuring rule
+    // Set matched kind to a MAX VALUE to implement largest, first occurring rule
     // i.e., smallest kind value matched should be used.
     image = jjimage;
     image.setLength(0);

--- a/src/main/resources/templates/TokenManagerBoilerPlateMethods.template
+++ b/src/main/resources/templates/TokenManagerBoilerPlateMethods.template
@@ -270,7 +270,7 @@ private ${STATIC?static :}final int jjMoveNfa(int startState, int curPos) {
       // We found a match. So remember the kind and position of the match.
       jjmatchedKind = kind;
       jjmatchedPos = curPos;
-      // Reset the kind to max value so we can contine looking for a longer
+      // Reset the kind to max value so we can continue looking for a longer
       // match.
       kind = Integer.MAX_VALUE;
     }
@@ -303,7 +303,7 @@ private ${STATIC?static :}final int jjMoveNfa(int startState, int curPos) {
   } while (cnt > 0);
 
   assert(false) :
-      "Interal error. Please submit a bug at: http://javacc.java.net.";
+      "Internal error. Please submit a bug at: http://javacc.java.net.";
   return curPos;
 }
 
@@ -417,7 +417,7 @@ public ${STATIC?static :} Token getNextToken() {
                        input_stream.getBeginColumn());
 #fi
 
-    // Set matched kind to a MAX VALUE to implement largest, first occuring rule
+    // Set matched kind to a MAX VALUE to implement largest, first occurring rule
     // i.e., smallest kind value matched should be used.
     image = jjimage;
     image.setLength(0);

--- a/src/main/resources/templates/TokenizerAlgorithm.template
+++ b/src/main/resources/templates/TokenizerAlgorithm.template
@@ -140,7 +140,7 @@ private ${STATIC?static :}final int jjMoveNfa(int startState, int curPos) {
   } while (!stateSet.empty());
 
   assert(false) :
-      "Interal error. Please submit a bug at: http://javacc.java.net.";
+      "Internal error. Please submit a bug at: http://javacc.java.net.";
   return curPos;
 }
 #fi

--- a/src/main/resources/templates/cpp/CharStream.h.template
+++ b/src/main/resources/templates/cpp/CharStream.h.template
@@ -72,7 +72,7 @@ public:
  * Backs up the input stream by amount steps. Lexer calls this method if it
  * had already read some characters, but could not use them to match a
  * (longer) token. So, they will be used again as the prefix of the next
- * token and it is the implemetation's responsibility to do this right.
+ * token and it is the implementation's responsibility to do this right.
  */
   virtual inline void backup(int amount) {
     inBuf += amount;

--- a/src/main/resources/templates/cpp/ErrorHandler.h.template
+++ b/src/main/resources/templates/cpp/ErrorHandler.h.template
@@ -32,7 +32,7 @@ JJSimpleString addUnicodeEscapes(const JJString& str);
       // Called when the parser cannot continue parsing.
       // last - the last token successfully parsed.
       // unexpected - the token at which the error occurs.
-      // production - the production in which this error occurrs.
+      // production - the production in which this error occurs.
       virtual void handleParseError(Token *last, Token *unexpected, const JJSimpleString& production, ${PARSER_NAME} *parser) {
         error_count++;
         fprintf(stderr, "Encountered: %s at: %d:%d while parsing: %s\n", addUnicodeEscapes(unexpected->image).c_str(), unexpected->beginLine, unexpected->beginColumn, production.c_str());

--- a/src/main/resources/templates/cpp/ParseException.cc.template
+++ b/src/main/resources/templates/cpp/ParseException.cc.template
@@ -52,7 +52,7 @@ namespace ${NAMESPACE_OPEN}
   /**
    * This is the last token that has been consumed successfully.  If
    * this object has been created due to a parse error, the token
-   * followng this token will (therefore) be the first error token.
+   * following this token will (therefore) be the first error token.
    */
   Token currentToken;
 

--- a/src/main/resources/templates/cpp/ParseException.h.template
+++ b/src/main/resources/templates/cpp/ParseException.h.template
@@ -50,7 +50,7 @@ class ParseException {
   /**
    * This is the last token that has been consumed successfully.  If
    * this object has been created due to a parse error, the token
-   * followng this token will (therefore) be the first error token.
+   * following this token will (therefore) be the first error token.
    */
   Token currentToken;
 

--- a/src/main/resources/templates/gwt/ParseException.template
+++ b/src/main/resources/templates/gwt/ParseException.template
@@ -74,7 +74,7 @@ public class ParseException extends Exception {
   /**
    * This is the last token that has been consumed successfully.  If
    * this object has been created due to a parse error, the token
-   * followng this token will (therefore) be the first error token.
+   * following this token will (therefore) be the first error token.
    */
   public Token currentToken;
 

--- a/test/exceptions/Parser.jj
+++ b/test/exceptions/Parser.jj
@@ -39,7 +39,7 @@ public class Parser {
   public static void main(String args[]) throws Exception {
     Parser t = new Parser(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 }
 

--- a/test/imports/Parser.jj
+++ b/test/imports/Parser.jj
@@ -39,7 +39,7 @@ public class Parser {
   public static void main(String args[]) throws Exception {
     Parser t = new Parser(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 }
 

--- a/test/javaFileGeneration/Parser.jj
+++ b/test/javaFileGeneration/Parser.jj
@@ -33,7 +33,7 @@ public class Parser {
   public static void main(String args[]) throws Exception {
     Parser t = new Parser(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 
 }

--- a/test/javaFileGeneration/expected/no-keep-line/ParseException.java
+++ b/test/javaFileGeneration/expected/no-keep-line/ParseException.java
@@ -58,7 +58,7 @@ public class ParseException extends Exception {
   /**
    * This is the last token that has been consumed successfully.  If
    * this object has been created due to a parse error, the token
-   * followng this token will (therefore) be the first error token.
+   * following this token will (therefore) be the first error token.
    */
   public Token currentToken;
 

--- a/test/javaFileGeneration/expected/no-keep-line/Parser.java
+++ b/test/javaFileGeneration/expected/no-keep-line/Parser.java
@@ -4,7 +4,7 @@ public class Parser implements ParserConstants {
   public static void main(String args[]) throws Exception {
     Parser t = new Parser(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 
   static final public void CompilationUnit() throws ParseException {

--- a/test/javaFileGeneration/expected/non-static/ParseException.java
+++ b/test/javaFileGeneration/expected/non-static/ParseException.java
@@ -58,7 +58,7 @@ public class ParseException extends Exception {
   /**
    * This is the last token that has been consumed successfully.  If
    * this object has been created due to a parse error, the token
-   * followng this token will (therefore) be the first error token.
+   * following this token will (therefore) be the first error token.
    */
   public Token currentToken;
 

--- a/test/javaFileGeneration/expected/non-static/Parser.java
+++ b/test/javaFileGeneration/expected/non-static/Parser.java
@@ -4,7 +4,7 @@ public class Parser implements ParserConstants {
   public static void main(String args[]) throws Exception {
     Parser t = new Parser(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 
   final public void CompilationUnit() throws ParseException {

--- a/test/javaFileGeneration/expected/not-public/ParseException.java
+++ b/test/javaFileGeneration/expected/not-public/ParseException.java
@@ -58,7 +58,7 @@ public class ParseException extends Exception {
   /**
    * This is the last token that has been consumed successfully.  If
    * this object has been created due to a parse error, the token
-   * followng this token will (therefore) be the first error token.
+   * following this token will (therefore) be the first error token.
    */
   public Token currentToken;
 

--- a/test/javaFileGeneration/expected/not-public/Parser.java
+++ b/test/javaFileGeneration/expected/not-public/Parser.java
@@ -4,7 +4,7 @@ public class Parser implements ParserConstants {
   public static void main(String args[]) throws Exception {
     Parser t = new Parser(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 
   static final public void CompilationUnit() throws ParseException {

--- a/test/javaFileGeneration/expected/static/ParseException.java
+++ b/test/javaFileGeneration/expected/static/ParseException.java
@@ -63,7 +63,7 @@ public class ParseException extends Exception {
   /**
    * This is the last token that has been consumed successfully.  If
    * this object has been created due to a parse error, the token
-   * followng this token will (therefore) be the first error token.
+   * following this token will (therefore) be the first error token.
    */
   public Token currentToken;
 

--- a/test/javaFileGeneration/expected/static/Parser.java
+++ b/test/javaFileGeneration/expected/static/Parser.java
@@ -4,7 +4,7 @@ public class Parser implements ParserConstants {
   public static void main(String args[]) throws Exception {
     Parser t = new Parser(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 
   static final public void CompilationUnit() throws ParseException {

--- a/test/javaFiles/Multi.jjt
+++ b/test/javaFiles/Multi.jjt
@@ -36,7 +36,7 @@ public class Tree {
   public static void main(String args[]) throws Exception {
     Tree t = new Tree(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 
 }

--- a/test/javaFiles/Parser.jj
+++ b/test/javaFiles/Parser.jj
@@ -36,7 +36,7 @@ public class Parser {
   public static void main(String args[]) throws Exception {
     Parser t = new Parser(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 
 }

--- a/test/javaFiles/StaticParser.jj
+++ b/test/javaFiles/StaticParser.jj
@@ -36,7 +36,7 @@ public class Parser {
   public static void main(String args[]) throws Exception {
     Parser t = new Parser(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 
 }

--- a/test/javaFiles/Tree.jjt
+++ b/test/javaFiles/Tree.jjt
@@ -36,7 +36,7 @@ public class Tree {
   public static void main(String args[]) throws Exception {
     Tree t = new Tree(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 
 }

--- a/test/javacodeLA/javacode.jj
+++ b/test/javacodeLA/javacode.jj
@@ -91,7 +91,7 @@ void NoJavacode() : {}
 }
 
 /*
-* For sematic lookahead, the LA executes as expected (only
+* For semantic lookahead, the LA executes as expected (only
 * succeeds if both the semantic and normal LA succeeds).
 */
 

--- a/test/newToken/OldToken.java
+++ b/test/newToken/OldToken.java
@@ -63,7 +63,7 @@ public class Token {
   }
 
   /**
-   * No-argument contructor
+   * No-argument constructor
    */
   public Token() {}
 

--- a/test/newToken/Parser.jj
+++ b/test/newToken/Parser.jj
@@ -36,7 +36,7 @@ public class Parser {
   public static void main(String args[]) throws Exception {
     Parser t = new Parser(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 
 }

--- a/test/newToken/ParserTokenFactory.jj
+++ b/test/newToken/ParserTokenFactory.jj
@@ -36,7 +36,7 @@ public class Parser {
   public static void main(String args[]) throws Exception {
     Parser t = new Parser(System.in);
     t.CompilationUnit();
-    System.out.println("Parser ran sucessfully");
+    System.out.println("Parser ran successfully");
   }
 
 }


### PR DESCRIPTION
Fixing some spelling errors as found by codespell. Some spelling errors also landed in the generated code, e.g. the templates, and are thus also seen in derived information.