### PR TITLE
Improve readabilty of jj_3R_XXX identifiers

### DIFF
--- a/src/main/java/org/javacc/parser/Expansion.java
+++ b/src/main/java/org/javacc/parser/Expansion.java
@@ -127,6 +127,21 @@ public class Expansion {
     return value;
   }
 
+  public String getProductionName() {
+    Object next = this;
+    // Limit the number of iterations in case there's a cycle
+    for (int i = 0; i < 42 && next != null; i++) {
+      if (next instanceof BNFProduction) {
+        return ((BNFProduction) next).getLhs();
+      } else if (next instanceof Expansion) {
+        next = ((Expansion) next).parent;
+      } else {
+        return null;
+      }
+    }
+    return null;
+  }
+
   /**
    * @param column the column to set
    */

--- a/src/main/java/org/javacc/parser/ParseEngine.java
+++ b/src/main/java/org/javacc/parser/ParseEngine.java
@@ -1096,7 +1096,7 @@ public class ParseEngine {
 //    new Error().codeGenerator.printStackTrace();
 //    System.out.println(" ***** seq: " + seq.internal_name + "; size: " + ((Sequence)seq).units.size());
 //    }
-      e.internal_name = "R_" + gensymindex;
+      e.internal_name = "R_" + e.getProductionName() + "_" + e.getLine()  + "_" + e.getColumn() + "_" + gensymindex;
       e.internal_index = gensymindex;
     }
     Phase3Data p3d = (Phase3Data)(phase3table.get(e));


### PR DESCRIPTION
For instance jj_3R_284 becomes jj_3R_ClassOrInterfaceDeclaration_1751_5_284
Where it includes parent (top level) production name, line number and column number.
284 is a sequence number as it was before.

Here's a sample from JavaCC.jj:

## Before

Note: it is generated by `bootstrap.jar`, so curly braces are placed slightly better.

```java
  private boolean jj_3R_342() {
    if (jj_scan_token(LPAREN)) return true;
    if (jj_3R_108()) return true;
    Token xsp;
    while (true) {
      xsp = jj_scanpos;
      if (jj_3_45()) { jj_scanpos = xsp; break; }
    }
    xsp = jj_scanpos;
    if (jj_scan_token(107)) jj_scanpos = xsp;
    if (jj_scan_token(RPAREN)) return true;
    return false;
  }

  private boolean jj_3R_344() {
    if (jj_scan_token(FINALLY)) return true;
    if (jj_3R_120()) return true;
    return false;
  }
```

## After

```java
  private boolean jj_3R_TryStatement_2848_10_342()
 {
    if (jj_scan_token(LPAREN)) return true;
    if (jj_3R_ResourceDeclaration_2829_3_108()) return true;
    Token xsp;
    while (true) {
      xsp = jj_scanpos;
      if (jj_3_45()) { jj_scanpos = xsp; break; }
    }
    xsp = jj_scanpos;
    if (jj_scan_token(107)) jj_scanpos = xsp;
    if (jj_scan_token(RPAREN)) return true;
    return false;
  }

  private boolean jj_3R_TryStatement_2852_5_344()
 {
    if (jj_scan_token(FINALLY)) return true;
    if (jj_3R_Block_2612_3_120()) return true;
    return false;
  }
```