### PR TITLE
Documentation of getNextToken

### DIFF
--- a/src/main/resources/templates/cpp/TokenManager.h.template
+++ b/src/main/resources/templates/cpp/TokenManager.h.template
@@ -16,10 +16,10 @@ namespace ${NAMESPACE_OPEN}
 
 class TokenManager {
 public:
-  /** This gets the next token from the input stream.
-   *  A token of kind 0 (<EOF>) should be returned on EOF.
-   */
   virtual       ~TokenManager() { }
+  /** This gets the next token from the input stream.
+   *  A token of kind 0 (`<EOF>`) should be returned on EOF.
+   */
   virtual Token *getNextToken() = 0;
   virtual void   setParser(void* parser) {};
   virtual void   lexicalError() {


### PR DESCRIPTION
- place documentation at right place
- see to it that <EOF> is handled properly in the documentation