### PR TITLE
Use StringBuilder in templates when GENERATE_STRING_BUILDER is used

### DIFF
--- a/src/main/java/org/javacc/utils/OutputFileGenerator.java
+++ b/src/main/java/org/javacc/utils/OutputFileGenerator.java
@@ -29,6 +29,8 @@ import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.javacc.parser.Options;
+
 /**
  * Generates boiler-plate files from templates. Only very basic
  * template processing is supplied - if we need something more
@@ -202,7 +204,11 @@ public class OutputFileGenerator {
     text = substitute(text);
     }
 
-  // TODO :: Added by Sreenivas on 12 June 2013 for 6.0 release, merged in to 6.1 release for sake of compatibility by cainsley ... This needs to be removed urgently!!!
+    if (Options.isOutputLanguageJava() && Options.getGenerateStringBuilder()) {
+        text = text.replace("StringBuffer", "StringBuilder");
+    }
+
+    // TODO :: Added by Sreenivas on 12 June 2013 for 6.0 release, merged in to 6.1 release for sake of compatibility by cainsley ... This needs to be removed urgently!!!
     if (text.startsWith("\\#")) { // Hack to escape # for C++
       text = text.substring(1);
     }

--- a/src/test/java/org/javacc/utils/OutputFileGeneratorTest.java
+++ b/src/test/java/org/javacc/utils/OutputFileGeneratorTest.java
@@ -1,0 +1,45 @@
+package org.javacc.utils;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.HashMap;
+
+import org.javacc.parser.JavaFiles.JavaResourceTemplateLocationImpl;
+import org.javacc.parser.Options;
+
+import junit.framework.TestCase;
+
+public class OutputFileGeneratorTest extends TestCase {
+
+  public void testStringBuffer() throws IOException {
+    Options.init();
+
+    JavaResourceTemplateLocationImpl impl = new JavaResourceTemplateLocationImpl();
+    OutputFileGenerator generator = new OutputFileGenerator(
+        impl.getParseExceptionTemplateResourceUrl(), new HashMap<>());
+    
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    generator.generate(writer);
+
+    assertTrue(stringWriter.toString().contains("StringBuffer"));
+    assertFalse(stringWriter.toString().contains("StringBuilder"));
+  }
+
+  public void testStringBuilder() throws IOException {
+    Options.init();
+    Options.setCmdLineOption(Options.USEROPTION__GENERATE_STRING_BUILDER);
+
+    JavaResourceTemplateLocationImpl impl = new JavaResourceTemplateLocationImpl();
+    OutputFileGenerator generator = new OutputFileGenerator(
+        impl.getParseExceptionTemplateResourceUrl(), new HashMap<>());
+
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    generator.generate(writer);
+
+    assertTrue(stringWriter.toString().contains("StringBuilder"));
+    assertFalse(stringWriter.toString().contains("StringBuffer"));
+  }
+}


### PR DESCRIPTION
Fixes #165 
