### PR TITLE
Tidy docs to consistently point to 7.0.9 release

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,10 +9,10 @@ title: JavaCC
 description: The most popular parser generator for use with Java applications.
 
 # Latest release
-version: 7.0.5
+version: 7.0.9
 
 # Site URLs
 github:
   contributors_url: https://github.com/javacc/javacc/graphs/contributors
-  zip_url: https://github.com/javacc/javacc/archive/7.0.5.zip
-  tar_url: https://github.com/javacc/javacc/archive/7.0.5.tar.gz
+  zip_url: https://github.com/javacc/javacc/archive/7.0.9.zip
+  tar_url: https://github.com/javacc/javacc/archive/7.0.9.tar.gz

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -4,12 +4,11 @@
 
 ### <a name="stable"></a>All stable releases
 
-JavaCC 7.0.10 is our latest stable release.
+JavaCC 7.0.9 is our latest stable release.
 
 All JavaCC releases are available via [GitHub](https://github.com/javacc/javacc/releases) and [Maven](https://mvnrepository.com/artifact/net.java.dev.javacc/javacc) including checksums and cryptographic signatures.
 
 #### 7.0.x
-* JavaCC 7.0.9 - 2020-06-22 ([Source (zip)](https://github.com/javacc/javacc/archive/javacc-7.0.10.zip), [Source (tar.gz)](https://github.com/javacc/javacc/archive/javacc-7.0.10.tar.gz), [Binaries](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.10/javacc-7.0.10.jar), [Javadocs](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.10/javacc-7.0.10-javadoc.jar), [Release Notes](release-notes.md#javacc-7.0.10))
 * JavaCC 7.0.9 - 2020-06-22 ([Source (zip)](https://github.com/javacc/javacc/archive/javacc-7.0.9.zip), [Source (tar.gz)](https://github.com/javacc/javacc/archive/javacc-7.0.9.tar.gz), [Binaries](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.9/javacc-7.0.9.jar), [Javadocs](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.9/javacc-7.0.9-javadoc.jar), [Release Notes](release-notes.md#javacc-7.0.9))
 * JavaCC 7.0.8 - 2020-06-22 ([Source (zip)](https://github.com/javacc/javacc/archive/javacc-7.0.8.zip), [Source (tar.gz)](https://github.com/javacc/javacc/archive/javacc-7.0.8.tar.gz), [Binaries](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.8/javacc-7.0.8.jar), [Javadocs](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.8/javacc-7.0.8-javadoc.jar), [Release Notes](release-notes.md#javacc-7.0.8))
 * JavaCC 7.0.7 - 2019-10-14 ([Source (zip)](https://github.com/javacc/javacc/archive/javacc-7.0.7.zip), [Source (tar.gz)](https://github.com/javacc/javacc/archive/javacc-7.0.7.tar.gz), [Binaries](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.7/javacc-7.0.7.jar), [Javadocs](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.7/javacc-7.0.7-javadoc.jar), [Release Notes](release-notes.md#javacc-7.0.7))

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,7 +159,7 @@ JavaCC 7.0.9 is our latest stable release.
 
 All JavaCC releases are available via [GitHub](https://github.com/javacc/javacc/releases) and [Maven](https://mvnrepository.com/artifact/net.java.dev.javacc/javacc) including checksums and cryptographic signatures.
 
-For all previous releases, please see [stable releases](docs/downloads.md).
+For all previous releases, please see [stable releases](downloads.md).
 
 The GitHub  8.0 branch contains the next generation of JavaCC that splits the frontend -- the JavaCC parser -- from the backends -- the code generator targeted for Java, C++ &and C# --. Status of JavaCC is experimental and not production ready.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -152,9 +152,10 @@ This guide will walk you through locally building the project, running an existi
 
 ### <a name="download"></a>Download & Installation
 
-JavaCC 7.0.10 is our latest stable release.
+JavaCC 7.0.9 is our latest stable release.
 
-* JavaCC 7.0.10 - ([Source (zip)](https://github.com/javacc/javacc/archive/javacc-7.0.10.zip), [Source (tar.gz)](https://github.com/javacc/javacc/archive/javacc-7.0.10.tar.gz), [Binaries](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.10/javacc-7.0.10.jar), [Javadocs](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.10/javacc-7.0.10-javadoc.jar), [Release Notes](docs/release-notes.md#javacc-7.0.10))
+* JavaCC 7.0.9 - ([Source (zip)](https://github.com/javacc/javacc/archive/javacc-7.0.9.zip), [Source (tar.gz)](https://github.com/javacc/javacc/archive/javacc-7.0.9.tar.gz), [Binaries](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.9/javacc-7.0.9.jar), [Javadocs](https://repo1.maven.org/maven2/net/java/dev/javacc/javacc/7.0.9/javacc-7.0.9-javadoc.jar), [Release Notes](release-notes.md#javacc-7.0.9))
+
 
 All JavaCC releases are available via [GitHub](https://github.com/javacc/javacc/releases) and [Maven](https://mvnrepository.com/artifact/net.java.dev.javacc/javacc) including checksums and cryptographic signatures.
 
@@ -167,16 +168,16 @@ The GitHub  8.0 branch contains the next generation of JavaCC that splits the fr
 To install JavaCC, navigate to the download directory and type:
 
 ```
-$ unzip javacc-7.0.10.zip
+$ unzip javacc-7.0.9.zip
 or
-$ tar xvf javacc-7.0.10.tar.gz
+$ tar xvf javacc-7.0.9.tar.gz
 ```
 
-Then place the binary `javacc-7.0.10.jar` in a new `target/` folder, and rename to `javacc.jar`.
+Then place the binary `javacc-7.0.9.jar` in a new `target/` folder, and rename to `javacc.jar`.
 
 Once you have completed installation add the `scripts/` directory in the JavaCC installation to your `PATH`. The JavaCC, JJTree, and JJDoc invocation scripts/executables reside in this directory.
 
-On UNIX based systems, the scripts may not be executable immediately. This can be solved by using the command from the `javacc-7.0.10/` directory:
+On UNIX based systems, the scripts may not be executable immediately. This can be solved by using the command from the `javacc-7.0.9/` directory:
 
 ```
 chmod +x scripts/javacc


### PR DESCRIPTION
Previous releases have not changed all the references consistently, so front page points to 7.0.6, release notes point to 7.0.10. Have changed all references to point to 7.0.9, which is the latest available release on GitHub and Maven.