### PR TITLE
Fix NPE in ParseException.initialise

### DIFF
--- a/src/main/resources/templates/ParseException.template
+++ b/src/main/resources/templates/ParseException.template
@@ -119,7 +119,9 @@ public class ParseException extends Exception {
       tok = tok.next;
     }
 #if KEEP_LINE_COLUMN
-    retval += "\" at line " + currentToken.next.beginLine + ", column " + currentToken.next.beginColumn;
+    if (currentToken.next != null) {
+      retval += "\" at line " + currentToken.next.beginLine + ", column " + currentToken.next.beginColumn;
+    }
 #fi
     retval += "." + EOL;
     


### PR DESCRIPTION
@don-vip reported this problem in 2015 as [JAVACC-289](http://web.archive.org/web/20150928070826/https://java.net/jira/browse/JAVACC-289). It was confirmed to be fixed in JavaCC, but the error resurfaced as @JOSM bug https://josm.openstreetmap.de/ticket/19685