### PR TITLE
feat: implements STATIC_EXCEPTION to improve performance

### DIFF
--- a/src/main/java/org/javacc/parser/Options.java
+++ b/src/main/java/org/javacc/parser/Options.java
@@ -107,6 +107,7 @@ public class Options {
 	public static final String USEROPTION__TOKEN_FACTORY = "TOKEN_FACTORY";
 	public static final String USEROPTION__TOKEN_EXTENDS = "TOKEN_EXTENDS";
 	public static final String USEROPTION__DEPTH_LIMIT = "DEPTH_LIMIT";
+	public static final String USEROPTION__STATIC_EXCEPTION = "STATIC_EXCEPTION";
 
 	public static final String USEROPTION__TOKEN_MANAGER_USES_PARSER = "TOKEN_MANAGER_USES_PARSER";
 
@@ -218,6 +219,8 @@ public class Options {
 
 		temp.add(new OptionInfo(USEROPTION__DEPTH_LIMIT, OptionType.INTEGER, Integer.valueOf(0)));
 		temp.add(new OptionInfo(USEROPTION__CPP_STACK_LIMIT, OptionType.STRING, ""));
+
+		temp.add(new OptionInfo(USEROPTION__STATIC_EXCEPTION, OptionType.BOOLEAN, Boolean.FALSE));
 
 		userOptions = Collections.unmodifiableSet(temp);
 	}

--- a/src/main/resources/templates/JavaCharStream.template
+++ b/src/main/resources/templates/JavaCharStream.template
@@ -8,6 +8,9 @@ public
 #fi
 class JavaCharStream
 {
+#if STATIC_EXCEPTION
+  private static final java.io.IOException ioException = new java.io.IOException();
+#fi
   /** Whether parser is static. */
   public static final boolean staticFlag = ${STATIC};
 
@@ -155,7 +158,11 @@ class JavaCharStream
                                           4096 - maxNextCharInd)) == -1)
       {
         inputStream.close();
+#if STATIC_EXCEPTION
+        throw ioException;
+#else
         throw new java.io.IOException();
+#fi
       }
       else
          maxNextCharInd += i;


### PR DESCRIPTION
Hi, we are heavy OGNL users.
While improving the performance of the OGNL parser, we found that the cost of generating a stack trace for IOException on FillBuf was a problem.
IOException is used for non-local exits, and I thought the stack trace was unnecessary.
we implemented an option to avoid the stack trace generation on instantiation by making an exception for a static member.
In our workload, we were able to save 20% of the total time.