### PR TITLE
Fix mismatched javadoc

### DIFF
--- a/src/main/resources/templates/gwt/Provider.template
+++ b/src/main/resources/templates/gwt/Provider.template
@@ -5,8 +5,8 @@ public interface Provider {
     /**
      * Reads characters into an array
      * @param buffer  Destination buffer
-     * @param offset   Offset at which to start storing characters
-     * @param length   The maximum possible number of characters to read
+     * @param offset  Offset at which to start storing characters
+     * @param len     The maximum possible number of characters to read
      * @return The number of characters read, or -1 if all read
      * @exception  IOException
      */


### PR DESCRIPTION
Mismatched parameter name in Javadoc leads to an error when generating Javadoc.