### PR TITLE
Generate max. one deprecated annotation per method

### DIFF
--- a/src/main/resources/templates/gwt/SimpleCharStream.template
+++ b/src/main/resources/templates/gwt/SimpleCharStream.template
@@ -215,14 +215,13 @@ ${SUPPORT_CLASS_VISIBILITY_PUBLIC?public :}class SimpleCharStream
     return c;
   }
 
-#if GENERATE_ANNOTATIONS
-  @Deprecated
-#fi
   /**
    * @deprecated
    * @see #getEndColumn
    */
+#if GENERATE_ANNOTATIONS
   @Deprecated
+#fi
   ${PREFIX}public int getColumn() {
 #if KEEP_LINE_COLUMN
     return bufcolumn[bufpos];
@@ -231,14 +230,13 @@ ${SUPPORT_CLASS_VISIBILITY_PUBLIC?public :}class SimpleCharStream
 #fi
   }
 
-#if GENERATE_ANNOTATIONS
-  @Deprecated
-#fi
   /**
    * @deprecated
    * @see #getEndLine
    */
+#if GENERATE_ANNOTATIONS
   @Deprecated
+#fi
   ${PREFIX}public int getLine() {
 #if KEEP_LINE_COLUMN
     return bufline[bufpos];


### PR DESCRIPTION
Should fix regression from https://github.com/javacc/javacc/pull/208, untested