### PR TITLE
Fix annotations for JavaCharStream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
 									<arg line="examples/GUIParsing/ParserVersion/CalcInput.jj" />
 								</java>
 								<javac fork="true" srcdir="test.tmp/GUIParsing/ParserVersion" />
-								<!-- 
+								<!--
 								<echo />
 								<copy todir="test.tmp/GUIParsing/TokenMgrVersion">
 									<fileset dir="examples/GUIParsing/TokenMgrVersion">
@@ -318,7 +318,7 @@
 									</fileset>
 								</copy>
 								<java failonerror="true" fork="true" classname="javacc" classpath="target/classes">
-									<arg line="-OUTPUT_DIRECTORY=test.tmp/GUIParsing/TokenMgrVersion" /> 
+									<arg line="-OUTPUT_DIRECTORY=test.tmp/GUIParsing/TokenMgrVersion" />
 									<arg line="examples/GUIParsing/TokenMgrVersion/CalcInput.jj" />
 								</java>
 								<javac fork="true" srcdir="test.tmp/GUIParsing/TokenMgrVersion" />
@@ -554,6 +554,21 @@
 									<arg line="examples/Obfuscator/MapFile.jj" />
 								</java>
 								<javac fork="true" srcdir="test.tmp/Obfuscator" />
+
+								<echo />
+								<java failonerror="true" fork="true" classname="javacc" classpath="target/classes">
+									<arg line="-OUTPUT_DIRECTORY=test.tmp/gwtTemplate" />
+									<arg line="test/gwtTemplate/Parser.jj" />
+								</java>
+								<javac fork="true" srcdir="test.tmp/gwtTemplate" />
+
+								<echo />
+								<java failonerror="true" fork="true" classname="javacc" classpath="target/classes">
+									<arg line="-OUTPUT_DIRECTORY=test.tmp/gwtUnicodeTemplate" />
+									<arg line="test/gwtUnicodeTemplate/Parser.jj" />
+								</java>
+								<javac fork="true" srcdir="test.tmp/gwtUnicodeTemplate" />
+
 								<!-- TODO, test cases for SimpleExamples -->
 								<echo />
 								<copy todir="test.tmp/Transformer">
@@ -647,7 +662,7 @@
 					</execution>
 				</executions>
 			</plugin>
-  <!-- 
+  <!--
   			<plugin>
 				<artifactId>maven-jarsigner-plugin</artifactId>
 				<executions>

--- a/src/main/resources/templates/gwt/JavaCharStream.template
+++ b/src/main/resources/templates/gwt/JavaCharStream.template
@@ -2,7 +2,7 @@
  * An implementation of interface CharStream, where the stream is assumed to
  * contain only ASCII characters (with java-like unicode escape processing).
  */
- 
+
 
 #if SUPPORT_CLASS_VISIBILITY_PUBLIC
 public
@@ -380,14 +380,13 @@ class JavaCharStream
     }
   }
 
-#if GENERATE_ANNOTATIONS
-  @Deprecated
-#fi
   /**
    * @deprecated
    * @see #getEndColumn
    */
+#if GENERATE_ANNOTATIONS
   @Deprecated
+#fi
   ${PREFIX}public int getColumn() {
 #if KEEP_LINE_COLUMN
     return bufcolumn[bufpos];
@@ -396,14 +395,13 @@ class JavaCharStream
 #fi
   }
 
-#if GENERATE_ANNOTATIONS
-  @Deprecated
-#fi
   /**
    * @deprecated
    * @see #getEndLine
    */
+#if GENERATE_ANNOTATIONS
   @Deprecated
+#fi
   ${PREFIX}public int getLine() {
 #if KEEP_LINE_COLUMN
     return bufline[bufpos];

--- a/test/gwtTemplate/Parser.jj
+++ b/test/gwtTemplate/Parser.jj
@@ -1,0 +1,76 @@
+/* Copyright (c) 2006, Sun Microsystems, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Sun Microsystems, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+options {
+  LOOKAHEAD = 1;
+  CHOICE_AMBIGUITY_CHECK = 2;
+  OTHER_AMBIGUITY_CHECK = 1;
+  STATIC = true;
+  DEBUG_PARSER = false;
+  DEBUG_LOOKAHEAD = false;
+  DEBUG_TOKEN_MANAGER = false;
+  ERROR_REPORTING = true;
+  JAVA_UNICODE_ESCAPE = false;
+  UNICODE_INPUT = false;
+  IGNORE_CASE = false;
+  USER_TOKEN_MANAGER = false;
+  USER_CHAR_STREAM = false;
+  BUILD_PARSER = true;
+  BUILD_TOKEN_MANAGER = true;
+  SANITY_CHECK = true;
+  FORCE_LA_CHECK = false;
+  JAVA_TEMPLATE_TYPE = "modern";
+}
+
+PARSER_BEGIN(Parser)
+
+import java.io.IOException;
+
+/** Simple brace matcher. */
+public class Parser {
+
+  /** Main entry point. */
+  public static void main(String args[]) throws ParseException, IOException {
+    Parser parser = new Parser(new StreamProvider(System.in));
+    parser.Input();
+  }
+
+}
+
+PARSER_END(Parser)
+
+/** Root production. */
+void Input() :
+{}
+{
+
+  "A"  {
+     System.out.println("hello");
+  } <EOF>
+}

--- a/test/gwtUnicodeTemplate/Parser.jj
+++ b/test/gwtUnicodeTemplate/Parser.jj
@@ -1,0 +1,76 @@
+/* Copyright (c) 2006, Sun Microsystems, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Sun Microsystems, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+options {
+  LOOKAHEAD = 1;
+  CHOICE_AMBIGUITY_CHECK = 2;
+  OTHER_AMBIGUITY_CHECK = 1;
+  STATIC = true;
+  DEBUG_PARSER = false;
+  DEBUG_LOOKAHEAD = false;
+  DEBUG_TOKEN_MANAGER = false;
+  ERROR_REPORTING = true;
+  JAVA_UNICODE_ESCAPE = true;
+  UNICODE_INPUT = false;
+  IGNORE_CASE = false;
+  USER_TOKEN_MANAGER = false;
+  USER_CHAR_STREAM = false;
+  BUILD_PARSER = true;
+  BUILD_TOKEN_MANAGER = true;
+  SANITY_CHECK = true;
+  FORCE_LA_CHECK = false;
+  JAVA_TEMPLATE_TYPE = "modern";
+}
+
+PARSER_BEGIN(Parser)
+
+import java.io.IOException;
+
+/** Simple brace matcher. */
+public class Parser {
+
+  /** Main entry point. */
+  public static void main(String args[]) throws ParseException, IOException {
+    Parser parser = new Parser(new StreamProvider(System.in));
+    parser.Input();
+  }
+
+}
+
+PARSER_END(Parser)
+
+/** Root production. */
+void Input() :
+{}
+{
+
+  "A"  {
+       System.out.println("hello");
+  } <EOF>
+}


### PR DESCRIPTION
The same problem as in SimpleCharStream (fixed in #222) also occured in JavaCharStream, fixed in this PR. I was also able to add some tests to verify that the GWT-compatible templates now produce valid Java code with both stream implementations.