### PR TITLE
Production part in javacc_input cannot be omitted

### DIFF
--- a/docs/documentation/grammar.md
+++ b/docs/documentation/grammar.md
@@ -66,7 +66,7 @@ javacc_input ::= javacc_options
                  "PARSER_BEGIN" "(" <IDENTIFIER> ")"
                  java_compilation_unit
                  "PARSER_END" "(" <IDENTIFIER> ")"
-                 ( production )*
+                 ( production )+
                  <EOF>
 ```
 


### PR DESCRIPTION
According to [bnf](https://github.com/javacc/javacc/blob/master/docs/documentation/bnf.md) and the actual compile / run results, `production` part in `javacc_input` cannot be omitted.

```bnf
javacc_input ::= javacc_options
                 "PARSER_BEGIN" "(" identifier ")"
                 CompilationUnit
                 "PARSER_END" "(" identifier ")"
                 ( production )+
                 <EOF>
```