### PR TITLE
fix: Remove redundant cast in TokenMgrError template

### DIFF
--- a/src/main/resources/templates/TokenMgrError.template
+++ b/src/main/resources/templates/TokenMgrError.template
@@ -103,7 +103,7 @@ ${SUPPORT_CLASS_VISIBILITY_PUBLIC?public :}class ${LEGACY_EXCEPTION_HANDLING?Tok
     return("Lexical error at line " + //
           errorLine + ", column " + //
           errorColumn + ".  Encountered: " + //
-          (EOFSeen ? "<EOF>" : ("'" + addEscapes(String.valueOf(curChar)) + "' (" + (int)curChar + "),")) + //
+          (EOFSeen ? "<EOF>" : ("'" + addEscapes(String.valueOf(curChar)) + "' (" + curChar + "),")) + //
           (errorAfter == null || errorAfter.length() == 0 ? "" : " after prefix \"" + addEscapes(errorAfter) + "\"")) + //
           (lexState == 0 ? "" : " (in lexical state " + lexState + ")");
   }


### PR DESCRIPTION
Compiling the generated `TokenMgrError.java`  with a recent JDK (tested on JDK 17) results in a warning

    TokenMgrError.java:108: warning: [cast] redundant cast to int
          (EOFSeen ? "<EOF>" : ("'" + addEscapes(String.valueOf(curChar)) + "' (" + (int)curChar + "),")) + /

`curChar` is an `int` argument to the `LexicalErr` method, and so does not need to be cast.