### PR TITLE
Try to fix `{{{{{}}}}}` issue in GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This example recognizes matching braces followed by zero or more line terminator
 
 Examples of legal strings in this grammar are:
 
-`{}`, `{{{{{}}}}}` // ... etc
+`{}`, `{{{{‎{}}}}}` // ... etc
 
 Examples of illegal strings are:
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This example recognizes matching braces followed by zero or more line terminator
 
 Examples of legal strings in this grammar are:
 
-`{}`, `{{{{‎{}}}}}` // ... etc
+`{}`, `{‎{‎{‎{‎{}}}}}` // ... etc
 
 Examples of illegal strings are:
 


### PR DESCRIPTION
Add zero-width space to display `{{{{{}}}}}` correctly both in Markdown and GitHub Pages