### PR TITLE
issue #246 Warnings regarding unused formal parameters in cpp templates

### DIFF
--- a/src/main/resources/templates/cpp/CharStream.h.template
+++ b/src/main/resources/templates/cpp/CharStream.h.template
@@ -30,7 +30,7 @@ namespace ${NAMESPACE_OPEN}
 class CharStream {
 public:
    void setTabSize(int i) { tabSize = i; }
-   int  getTabSize(int i) { return tabSize; }
+   int  getTabSize(int /*i*/) { return tabSize; }
 
 #if KEEP_LINE_COLUMN
 private:

--- a/src/main/resources/templates/cpp/ErrorHandler.h.template
+++ b/src/main/resources/templates/cpp/ErrorHandler.h.template
@@ -25,7 +25,7 @@ JJSimpleString addUnicodeEscapes(const JJString& str);
       // expectedKind - token kind that the parser was trying to consume.
       // expectedToken - the image of the token - tokenImages[expectedKind].
       // actual - the actual token that the parser got instead.
-      virtual void handleUnexpectedToken(int expectedKind, const JJString& expectedToken, Token *actual, ${PARSER_NAME} *parser) {
+      virtual void handleUnexpectedToken(int /*expectedKind*/, const JJString& expectedToken, Token *actual, ${PARSER_NAME} */*parser*/) {
         error_count++;
         fprintf(stderr, "Expecting %s at: %d:%d but got %s\n", addUnicodeEscapes(expectedToken).c_str(), actual->beginLine, actual->beginColumn, addUnicodeEscapes(actual->image).c_str());
       }
@@ -33,14 +33,14 @@ JJSimpleString addUnicodeEscapes(const JJString& str);
       // last - the last token successfully parsed.
       // unexpected - the token at which the error occurs.
       // production - the production in which this error occurs.
-      virtual void handleParseError(Token *last, Token *unexpected, const JJSimpleString& production, ${PARSER_NAME} *parser) {
+      virtual void handleParseError(Token */*last*/, Token *unexpected, const JJSimpleString& production, ${PARSER_NAME} */*parser*/) {
         error_count++;
         fprintf(stderr, "Encountered: %s at: %d:%d while parsing: %s\n", addUnicodeEscapes(unexpected->image).c_str(), unexpected->beginLine, unexpected->beginColumn, production.c_str());
       }
       virtual int getErrorCount() {
         return error_count;
       }
-      virtual void handleOtherError(const JJString& message, ${PARSER_NAME} *parser) {
+      virtual void handleOtherError(const JJString& message, ${PARSER_NAME} */*parser*/) {
         fprintf(stderr, "Error: %s\n", (char*)message.c_str());
       }
       virtual ~ErrorHandler() {}
@@ -65,11 +65,11 @@ JJSimpleString addUnicodeEscapes(const JJString& str);
        //    errorAfter  : prefix that was seen before this error occurred
        //    curchar     : the offending character
        //
-       virtual void lexicalError(bool EOFSeen, int lexState, int errorLine, int errorColumn, const JJString& errorAfter, JJChar curChar, ${PARSER_NAME}TokenManager* token_manager) {
+       virtual void lexicalError(bool EOFSeen, int /*lexState*/, int errorLine, int errorColumn, const JJString& errorAfter, JJChar curChar, ${PARSER_NAME}TokenManager* /*token_manager*/) {
         // by default, we just print an error message and return.
         fprintf(stderr, "Lexical error at: %d:%d. Encountered: %c after: %s.\n", errorLine, errorColumn, curChar, (EOFSeen? "EOF" : (const char*)errorAfter.c_str()));
       }
-       virtual void lexicalError(const JJString& errorMessage, ${PARSER_NAME}TokenManager* token_manager) {
+       virtual void lexicalError(const JJString& errorMessage, ${PARSER_NAME}TokenManager* /*token_manager*/) {
         fprintf(stderr, "%s\n", (char*)errorMessage.c_str());
       }
       virtual ~TokenManagerErrorHandler() {}

--- a/src/main/resources/templates/cpp/JavaCC.h.template
+++ b/src/main/resources/templates/cpp/JavaCC.h.template
@@ -43,7 +43,7 @@ static const JJChar JJQUOTE[] = { '\'', 0 };
 class ReaderStream {
 public:
   // Read block of data into a buffer and return the actual number read.
-  virtual size_t read(JAVACC_CHAR_TYPE *buffer, int offset, size_t len) { return 0; }
+  virtual size_t read(JAVACC_CHAR_TYPE */*buffer*/, int /*offset*/, size_t /*len*/) { return 0; }
   virtual bool   endOfInput() { return true; }
   virtual ~ReaderStream() {}
 };

--- a/src/main/resources/templates/cpp/TokenManager.h.template
+++ b/src/main/resources/templates/cpp/TokenManager.h.template
@@ -21,7 +21,7 @@ public:
    *  A token of kind 0 (`<EOF>`) should be returned on EOF.
    */
   virtual Token *getNextToken() = 0;
-  virtual void   setParser(void* parser) {};
+  virtual void   setParser(void* /*parser*/) {};
   virtual void   lexicalError() {
   	std::cerr << "Lexical error encountered." << std::endl;
   }

--- a/src/main/resources/templates/gwt/JavaCharStream.template
+++ b/src/main/resources/templates/gwt/JavaCharStream.template
@@ -91,7 +91,7 @@ class JavaCharStream
 #fi
 
   ${PREFIX}public void setTabSize(int i) { tabSize = i; }
-  ${PREFIX}public int getTabSize(int i) { return tabSize; }
+  ${PREFIX}public int getTabSize(int /*i*/) { return tabSize; }
 
   ${PREFIX}protected void ExpandBuff(boolean wrapAround)
   {


### PR DESCRIPTION
Commented out the argument names so the warning will not appear. (`[[maybe_unused]]` would have been the nicer solution, but seen it is only available from standard c++-17 it is better for a bit a conservative way).