### PR TITLE
Fix javadoc errors in JavaCharStream.template

### DIFF
--- a/src/main/resources/templates/JavaCharStream.template
+++ b/src/main/resources/templates/JavaCharStream.template
@@ -501,7 +501,6 @@ class JavaCharStream
 
 /** Constructor.
  * @param dstream the underlying data source.
- * @param startline line number of the first character of the stream, mostly for error messages.
  */
   public JavaCharStream(java.io.Reader dstream)
   {
@@ -570,7 +569,7 @@ class JavaCharStream
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
   public JavaCharStream(java.io.InputStream dstream, String encoding, int startline,
                         int startcolumn) throws java.io.UnsupportedEncodingException
@@ -592,7 +591,7 @@ class JavaCharStream
 /** Constructor.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
   public JavaCharStream(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {
@@ -636,7 +635,7 @@ class JavaCharStream
  * @param encoding the character encoding of the data stream.
  * @param startline line number of the first character of the stream, mostly for error messages.
  * @param startcolumn column number of the first character of the stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
   public void ReInit(java.io.InputStream dstream, String encoding, int startline,
                      int startcolumn) throws java.io.UnsupportedEncodingException
@@ -656,7 +655,7 @@ class JavaCharStream
 /** Reinitialise.
  * @param dstream the underlying data source.
  * @param encoding the character encoding of the data stream.
- * @throws UnsupportedEncodingException encoding is invalid or unsupported.
+ * @throws java.io.UnsupportedEncodingException encoding is invalid or unsupported.
  */
   public void ReInit(java.io.InputStream dstream, String encoding) throws java.io.UnsupportedEncodingException
   {


### PR DESCRIPTION
Javadoc issues errors when processing code from the JavaCharStream template.  Most are due to unqualified use of UnsupportedEncodingException.  One is due to a @param string for a parameter that does not exist.  With this PR there are still many warnings, but no errors.