### PR TITLE
Changed template for ParseException: used StringBuilder instead of String

### DIFF
--- a/src/main/resources/templates/ParseException.template
+++ b/src/main/resources/templates/ParseException.template
@@ -104,40 +104,40 @@ public class ParseException extends Exception {
       }
       expected.append(EOL).append("    ");
     }
-    String retval = "Encountered \"";
+    StringBuilder retval = new StringBuilder("Encountered \"");
     Token tok = currentToken.next;
     for (int i = 0; i < maxSize; i++) {
-      if (i != 0) retval += " ";
+      if (i != 0) retval.append(" ");
       if (tok.kind == 0) {
-        retval += tokenImage[0];
+        retval.append(tokenImage[0]);
         break;
       }
-      retval += " " + tokenImage[tok.kind];
-      retval += " \"";
-      retval += add_escapes(tok.image);
-      retval += " \"";
+      retval.append(' ').append(tokenImage[tok.kind]);
+      retval.append(" \"");
+      retval.append(add_escapes(tok.image));
+      retval.append(" \"");
       tok = tok.next;
     }
 #if KEEP_LINE_COLUMN
     if (currentToken.next != null) {
-      retval += "\" at line " + currentToken.next.beginLine + ", column " + currentToken.next.beginColumn;
+      retval.append("\" at line ").append(currentToken.next.beginLine).append(", column ").append(currentToken.next.beginColumn);
     }
 #fi
-    retval += "." + EOL;
-    
-    
+    retval.append('.').append(EOL);
+
+
     if (expectedTokenSequences.length == 0) {
         // Nothing to add here
     } else {
 	    if (expectedTokenSequences.length == 1) {
-	      retval += "Was expecting:" + EOL + "    ";
+	      retval.append("Was expecting:").append(EOL).append("    ");
 	    } else {
-	      retval += "Was expecting one of:" + EOL + "    ";
+	      retval.append("Was expecting one of:").append(EOL).append("    ");
 	    }
-	    retval += expected.toString();
+	    retval.append(expected.toString());
     }
-    
-    return retval;
+
+    return retval.toString();
   }
 
 


### PR DESCRIPTION
Changed template for ParseException: used StringBuilder and chained calls of append() instead of string reassignment and string concatenation. Under the hood every string concatenation is translated to temporary StringBuilder object. That's performance related.