### PR TITLE
Incorrect handling of UNICODE characters in c++ generated code

### DIFF
--- a/src/main/java/org/javacc/parser/NfaState.java
+++ b/src/main/java/org/javacc/parser/NfaState.java
@@ -1672,13 +1672,26 @@ public class NfaState
       } else {
          if (Options.getJavaUnicodeEscape() || unicodeWarningGiven)
          {
-           codeGenerator.genCodeLine("         int hiByte = (curChar >> 8);");
+           if (!codeGenerator.isJavaLanguage()) {
+             codeGenerator.genCodeLine("         unsigned char curUChar;");
+             codeGenerator.genCodeLine("         curUChar = *((unsigned char *)&curChar);");
+             codeGenerator.genCodeLine("         int hiByte = (curUChar >> 8);");
+           } else {
+             codeGenerator.genCodeLine("         int hiByte = (curChar >> 8);");
+           }
            codeGenerator.genCodeLine("         int i1 = hiByte >> 6;");
            codeGenerator.genCodeLine("         " + Options.getLongType() + " l1 = 1L << (hiByte & 077);");
-         }
 
-         codeGenerator.genCodeLine("         int i2 = (curChar & 0xff) >> 6;");
-         codeGenerator.genCodeLine("         " + Options.getLongType() + " l2 = 1L << (curChar & 077);");
+           codeGenerator.genCodeLine("         int i2 = (curChar & 0xff) >> 6;");
+           if (!codeGenerator.isJavaLanguage()) {
+             codeGenerator.genCodeLine("         " + Options.getLongType() + " l2 = 1L << (curUChar & 077);");
+           } else {
+             codeGenerator.genCodeLine("         " + Options.getLongType() + " l2 = 1L << (curChar & 077);");
+           }
+         } else {
+           codeGenerator.genCodeLine("         int i2 = (curChar & 0xff) >> 6;");
+           codeGenerator.genCodeLine("         " + Options.getLongType() + " l2 = 1L << (curChar & 077);");
+        }
       }
 
       //codeGenerator.genCodeLine("         MatchLoop: do");
@@ -2948,14 +2961,14 @@ public class NfaState
       codeGenerator.genCodeLine("   {");
       codeGenerator.genCodeLine("      if (++jjround == 0x" + Integer.toHexString(Integer.MAX_VALUE) + ")");
       codeGenerator.genCodeLine("         ReInitRounds();");
-      codeGenerator.genCodeLine("      if (curChar < 64)");
+      codeGenerator.genCodeLine("      if (curChar >= 0 && curChar < 64)");
       codeGenerator.genCodeLine("      {");
 
       DumpAsciiMoves(codeGenerator, 0);
 
       codeGenerator.genCodeLine("      }");
 
-      codeGenerator.genCodeLine("      else if (curChar < 128)");
+      codeGenerator.genCodeLine("      else if (curChar >= 0 && curChar < 128)");
 
       codeGenerator.genCodeLine("      {");
 


### PR DESCRIPTION
Between lathe Java language and the C++ language there is a major difference regarding the char data type. In Java this is a `signed` data type with numerical values `0...255` but in C++ this is an `unsigned` quantity with numerical values `-128...127`. In the code this means that the original line 2951 would also kick in for the unicode values (typical having the high bit set) instead of the code created originally at 2966 (the `else`). Also the handling of the `hiByte` / `i1` / `i2` as of original line 1674 has to be corrected so that the shifts are done on unsigned values.

As far as I could tell the corrected places are the only places where the problem occurs.

Disclaimer: I have not been able to test the actual Java code due to a lack of infrastructure, I did test the results by adjusting the generated C++ code in the original project

Original, doxygen, issues https://github.com/doxygen/doxygen/issues/5454 and https://github.com/doxygen/doxygen/issues/10104