### PR TITLE
Throw a static instance in FillBuff

### DIFF
--- a/src/main/resources/templates/JavaCharStream.template
+++ b/src/main/resources/templates/JavaCharStream.template
@@ -144,6 +144,15 @@ class JavaCharStream
     tokenBegin = 0;
   }
 
+  static private final class EOSException extends java.io.IOException {
+    @Override
+    public Throwable fillInStackTrace() {
+      return this;
+    }
+  }
+
+  private static final java.io.IOException STATIC_FILLBUFF_EXCEPTION = new EOSException();
+
   ${PREFIX}protected void FillBuff() throws java.io.IOException
   {
     int i;
@@ -155,7 +164,7 @@ class JavaCharStream
                                           4096 - maxNextCharInd)) == -1)
       {
         inputStream.close();
-        throw new java.io.IOException();
+        throw STATIC_FILLBUFF_EXCEPTION;
       }
       else
          maxNextCharInd += i;

--- a/src/main/resources/templates/SimpleCharStream.template
+++ b/src/main/resources/templates/SimpleCharStream.template
@@ -95,6 +95,15 @@ ${SUPPORT_CLASS_VISIBILITY_PUBLIC?public :}class SimpleCharStream
     tokenBegin = 0;
   }
 
+  static private final class EOSException extends java.io.IOException {
+    @Override
+    public Throwable fillInStackTrace() {
+      return this;
+    }
+  }
+
+  private static final java.io.IOException STATIC_FILLBUFF_EXCEPTION = new EOSException();
+
   ${PREFIX}protected void FillBuff() throws java.io.IOException
   {
     if (maxNextCharInd == available)
@@ -124,7 +133,7 @@ ${SUPPORT_CLASS_VISIBILITY_PUBLIC?public :}class SimpleCharStream
       if ((i = inputStream.read(buffer, maxNextCharInd, available - maxNextCharInd)) == -1)
       {
         inputStream.close();
-        throw new java.io.IOException();
+        throw STATIC_FILLBUFF_EXCEPTION;
       }
       else
         maxNextCharInd += i;

--- a/src/main/resources/templates/gwt/JavaCharStream.template
+++ b/src/main/resources/templates/gwt/JavaCharStream.template
@@ -146,6 +146,15 @@ class JavaCharStream
     tokenBegin = 0;
   }
 
+  static private final class EOSException extends java.io.IOException {
+    @Override
+    public Throwable fillInStackTrace() {
+      return this;
+    }
+  }
+
+  private static final java.io.IOException STATIC_FILLBUFF_EXCEPTION = new EOSException();
+
   ${PREFIX}protected void FillBuff() throws java.io.IOException
   {
     int i;
@@ -157,7 +166,7 @@ class JavaCharStream
                                           4096 - maxNextCharInd)) == -1)
       {
         inputStream.close();
-        throw new java.io.IOException();
+        throw STATIC_FILLBUFF_EXCEPTION;
       }
       else
          maxNextCharInd += i;

--- a/src/main/resources/templates/gwt/SimpleCharStream.template
+++ b/src/main/resources/templates/gwt/SimpleCharStream.template
@@ -95,6 +95,15 @@ ${SUPPORT_CLASS_VISIBILITY_PUBLIC?public :}class SimpleCharStream
     tokenBegin = 0;
   }
 
+  static private final class EOSException extends java.io.IOException {
+    @Override
+    public Throwable fillInStackTrace() {
+      return this;
+    }
+  }
+
+  private static final java.io.IOException STATIC_FILLBUFF_EXCEPTION = new EOSException();
+
   ${PREFIX}protected void FillBuff() throws java.io.IOException
   {
     if (maxNextCharInd == available)
@@ -124,7 +133,7 @@ ${SUPPORT_CLASS_VISIBILITY_PUBLIC?public :}class SimpleCharStream
       if ((i = inputStream.read(buffer, maxNextCharInd, available - maxNextCharInd)) == -1)
       {
         inputStream.close();
-        throw new java.io.IOException();
+        throw STATIC_FILLBUFF_EXCEPTION;
       }
       else
         maxNextCharInd += i;


### PR DESCRIPTION
Very similar to PR #99. Removes a lot of performance overhead from building stack traces that will be discarded.

Doing it in all places.