### PR TITLE
Broken link fixed at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ It includes [detailed documentation](docs/documentation/index.md) for JavaCC, JJ
 ##### Articles
 
 * [Looking for lex and yacc for Java? You don't know Jack](https://www.javaworld.com/article/2077315/looking-for-lex-and-yacc-for-java--you-don-t-know-jack.html) by Chuck Mcmanis.
-* [Build your own languages with JavaCC](https://www.javaworld.com/article/2076269/build-your-own-languages-with-javacc.html) by Oliver Enseling.
+* [Build your own languages with JavaCC](https://www.infoworld.com/article/2162779/build-your-own-languages-with-javacc.html) by Oliver Enseling.
 * [Writing an Interpreter Using JavaCC](https://anandsekar.github.io/writing-an-interpretter-using-javacc/) by Anand Rajasekar.
 * [Building a lexical analyzer with JavaCC](http://kiwwito.com/build-a-lexical-analyzer-with-javacc/) by Keyvan Akbary.
 


### PR DESCRIPTION
The broken link to "Build your own languages with JavaCC" article was fixed