### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ It includes [detailed documentation](docs/documentation/index.md) for JavaCC, JJ
 
 ##### Articles
 
-* [Looking for lex and yacc for Java? You don't know Jack](https://www.javaworld.com/article/2077315/looking-for-lex-and-yacc-for-java--you-don-t-know-jack.html) by Chuck Mcmanis.
+* [Looking for lex and yacc for Java? You don't know Jack](https://www.infoworld.com/article/2170636/looking-for-lex-and-yacc-for-java-you-don-t-know-jack.html) by Chuck Mcmanis.
 * [Build your own languages with JavaCC](https://www.infoworld.com/article/2162779/build-your-own-languages-with-javacc.html) by Oliver Enseling.
 * [Writing an Interpreter Using JavaCC](https://anandsekar.github.io/writing-an-interpretter-using-javacc/) by Anand Rajasekar.
 * [Building a lexical analyzer with JavaCC](http://kiwwito.com/build-a-lexical-analyzer-with-javacc/) by Keyvan Akbary.


### PR DESCRIPTION
The "Looking for lex and yacc for Java? You don’t know Jack" article URL was fixed.